### PR TITLE
Issue #10: Ingest node

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -89,3 +89,41 @@ Six stub nodes: `ingest`, `retrieve_context`, `extract_candidates`, `classify_th
 - Batch vs. per-document graph: batch-in-state. Simpler graph topology; `Send` available if needed later.
 
 ---
+
+## Issue #10 — Ingest node: wrap extraction, parse individual follow-up questions
+
+**Date:** 2026-03-24
+
+**Branch:** `issue-10-ingest-node`
+
+**What was built:**
+
+`ingest.py` — the ingest node implementation and supporting types. No LLM calls; everything here is deterministic and runs without API credentials.
+
+`IngestedDoc` and `SkippedDoc` TypedDicts — the first concrete state types. `GraphState` is narrowed from `list[Any]` to `list[IngestedDoc]` / `list[SkippedDoc]` for the ingest output fields.
+
+`parse_questions(blob)` — the new behavior this issue adds. Parses the `follow_up_questions` text blob from `extraction.py` into a `list[str]` of individual question strings. Handles: numbered lists (`1.`, `1)`), bulleted lists (`-`, `*`, `•`), bare newlines, and markdown bold (`**Q?**`). Each non-empty line after stripping markers becomes one question. Single dense paragraph on one line → one question.
+
+`run_ingest(manifest_docs)` — loops over raw manifest dicts, calls `extraction.extract()`, applies the gate check, parses questions, routes to `ingested_docs` or `skipped_docs`.
+
+`ingest` node in `graph.py` updated from stub to real implementation.
+
+`tests/fixtures/hard_case_note.txt` — representative fixture note with mixed formatting in the follow-up section: two numbered items, one bold question, one bulleted item.
+
+25 new tests in `tests/test_ingest.py`. 76 total tests pass.
+
+**Key decisions:**
+
+- **Per-line = per question.** The simplest parse rule that handles real data. Multi-line questions are rare; splitting on sentence boundaries is fragile and not attempted. Revisit with LangSmith evidence after real runs.
+
+- **Markdown bold stripped, not treated as a header.** `**Q?**` appears in real notes as emphasis, not a section marker. Stripping gives a clean question string.
+
+- **`ingest.py` as its own module.** Question parser and `run_ingest` are independently testable without LangGraph. Establishes the pattern: each substantial node gets its own module (`extract_candidates.py`, `classify_themes.py`, etc.).
+
+- **LangSmith trace:** LangGraph automatically traces the node. A `log.info` summary ("X docs — Y passed, Z skipped") appears in the trace logs alongside the `ingested_docs` / `skipped_docs` state diff.
+
+**Deferred:**
+
+- Multi-paragraph question parsing (rare in practice; revisit with real run evidence).
+
+---

--- a/src/documenters_cle_langchain/graph.py
+++ b/src/documenters_cle_langchain/graph.py
@@ -20,6 +20,8 @@ from typing import Any, TypedDict
 
 from langgraph.graph import StateGraph, END
 
+from .ingest import IngestedDoc, SkippedDoc, run_ingest
+
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -72,8 +74,8 @@ class GraphState(TypedDict):
     prior_decisions: list[Any]      # list[ReviewDecision] from prior run's classified notes tab
 
     # --- ingest output (Issue #10) ---
-    ingested_docs: list[Any]        # list[IngestedDoc] — extracted, gate-passed, questions parsed
-    skipped_docs: list[Any]         # list[SkippedDoc] — failed the required-field gate
+    ingested_docs: list[IngestedDoc]    # extracted, gate-passed, questions parsed
+    skipped_docs: list[SkippedDoc]      # failed the required-field gate
 
     # --- retrieve_context output (Issue #12) ---
     retrieval_context: list[Any]    # list[QuestionContext] — per-question similar themes from library
@@ -103,7 +105,8 @@ def ingest(state: GraphState) -> dict:
     Inputs:  manifest_docs
     Outputs: ingested_docs, skipped_docs
     """
-    return {}
+    ingested, skipped = run_ingest(state["manifest_docs"])
+    return {"ingested_docs": ingested, "skipped_docs": skipped}
 
 
 def retrieve_context(state: GraphState) -> dict:

--- a/src/documenters_cle_langchain/ingest.py
+++ b/src/documenters_cle_langchain/ingest.py
@@ -1,0 +1,182 @@
+"""ingest.py — deterministic document ingestion for the LangGraph agent.
+
+Wraps extraction.py and gate.py. Adds follow-up question parsing.
+Called by the `ingest` node in graph.py.
+
+No LLM calls. All logic here is deterministic and unit-testable without
+any API credentials.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import TypedDict
+
+from .extraction import extract
+from .gate import passes_extraction_gate
+
+log = logging.getLogger(__name__)
+
+# Strips leading list markers: "1. " "2) " "- " "* " "• "
+_MARKER_RE = re.compile(r"^\s*(\d+[\.\)]\s+|[-*•]\s+)")
+
+# Unwraps markdown bold/italic: **text** or *text*
+_BOLD_RE = re.compile(r"\*{1,2}(.+?)\*{1,2}")
+
+
+# ---------------------------------------------------------------------------
+# Output types
+# ---------------------------------------------------------------------------
+
+
+class IngestedDoc(TypedDict):
+    """A document that passed the gate, with follow-up questions parsed into a list."""
+
+    # source
+    doc_id: str
+    name: str
+    web_url: str
+    folder_path: str
+    modified_time: str
+    # extraction
+    meeting_name: str
+    documenter_name: str
+    agency: str
+    date: str | None        # ISO 8601 if parseable, else None
+    date_raw: str
+    documenters_url: str
+    summary: str
+    follow_up_questions: list[str]  # individual questions — primary analysis unit
+    notes: str
+    single_signal: str
+    extraction_confidence: float
+
+
+class SkippedDoc(TypedDict):
+    """A document that failed the required-field gate."""
+
+    doc_id: str
+    name: str
+    web_url: str
+    missing_fields: tuple[str, ...]
+    extraction_confidence: float
+
+
+# ---------------------------------------------------------------------------
+# Question parser
+# ---------------------------------------------------------------------------
+
+
+def parse_questions(blob: str) -> list[str]:
+    """Parse a follow-up questions blob into a list of individual question strings.
+
+    Handles all formatting variations found in real Documenters notes:
+    - Numbered lists (``1. Q`` or ``1) Q``)
+    - Bulleted lists (``- Q``, ``* Q``, ``• Q``)
+    - Bare lines (each non-empty line becomes a question)
+    - Markdown bold (``**Q?**`` → ``Q?``)
+    - Mixed formatting within the same section
+
+    A single line with no markers is returned as one question. Multiple
+    non-empty lines each become a separate question — splitting on sentence
+    boundaries is fragile and is not attempted.
+
+    Args:
+        blob: raw text from the follow-up questions section, as returned by
+              ``extraction.extract()``.
+
+    Returns:
+        List of question strings, stripped of markers and whitespace.
+        Empty list if the blob is empty or whitespace-only.
+    """
+    if not blob.strip():
+        return []
+
+    questions = []
+    for line in blob.splitlines():
+        # Strip leading list markers
+        cleaned = _MARKER_RE.sub("", line).strip()
+        # Unwrap markdown bold/italic
+        cleaned = _BOLD_RE.sub(r"\1", cleaned).strip()
+        if cleaned:
+            questions.append(cleaned)
+    return questions
+
+
+# ---------------------------------------------------------------------------
+# Ingest runner
+# ---------------------------------------------------------------------------
+
+
+def run_ingest(
+    manifest_docs: list[dict],
+) -> tuple[list[IngestedDoc], list[SkippedDoc]]:
+    """Run deterministic extraction and gate check over all manifest docs.
+
+    For each doc: extract structured fields, check required-field gate,
+    parse follow-up questions into individual items.
+
+    Args:
+        manifest_docs: raw doc dicts from the manifest JSON, as stored in
+                       ``GraphState["manifest_docs"]``.
+
+    Returns:
+        ``(ingested_docs, skipped_docs)`` — docs that passed the gate, and
+        docs that didn't.
+    """
+    ingested: list[IngestedDoc] = []
+    skipped: list[SkippedDoc] = []
+
+    for raw in manifest_docs:
+        doc_id = raw.get("doc_id") or raw.get("gdoc_id", "")
+        name = raw.get("name", "")
+        web_url = raw.get("web_url", "")
+
+        extraction = extract(doc_id=doc_id, text=raw.get("text", ""))
+
+        if not passes_extraction_gate(extraction):
+            log.warning(
+                "gate fail — skipping '%s' (missing: %s)", name, extraction.missing_fields
+            )
+            skipped.append(
+                SkippedDoc(
+                    doc_id=doc_id,
+                    name=name,
+                    web_url=web_url,
+                    missing_fields=extraction.missing_fields,
+                    extraction_confidence=extraction.confidence,
+                )
+            )
+            continue
+
+        questions = parse_questions(extraction.follow_up_questions)
+        log.debug("  '%s' — %d follow-up question(s) parsed", name, len(questions))
+
+        ingested.append(
+            IngestedDoc(
+                doc_id=doc_id,
+                name=name,
+                web_url=web_url,
+                folder_path=raw.get("folder_path", ""),
+                modified_time=raw.get("modified_time", ""),
+                meeting_name=extraction.meeting_name,
+                documenter_name=extraction.documenter_name,
+                agency=extraction.agency,
+                date=extraction.date,
+                date_raw=extraction.date_raw,
+                documenters_url=extraction.documenters_url,
+                summary=extraction.summary,
+                follow_up_questions=questions,
+                notes=extraction.notes,
+                single_signal=extraction.single_signal,
+                extraction_confidence=extraction.confidence,
+            )
+        )
+
+    log.info(
+        "ingest: %d docs — %d passed gate, %d skipped",
+        len(manifest_docs),
+        len(ingested),
+        len(skipped),
+    )
+    return ingested, skipped

--- a/tests/fixtures/hard_case_note.txt
+++ b/tests/fixtures/hard_case_note.txt
@@ -1,0 +1,24 @@
+Housing and Building Committee
+Documenter name: Renata Dobbs
+Agency: Cleveland City Council
+Date: February 12, 2026
+See more about this meeting at https://www.documenters.org/assignments/clev-2026-housing/
+
+## Summary
+Council discussed proposed amendments to the housing code, including changes to rental inspection requirements and a new weatherization assistance pilot program for low-income homeowners.
+
+## Follow-Up Questions
+1. How are landlords notified about the new inspection requirements, and what is the enforcement timeline?
+2. What funding source is the weatherization pilot drawing from — federal, state, or local?
+**Who decides which neighborhoods are eligible for the weatherization pilot?**
+- Are there appeals for landlords who dispute inspection findings?
+
+## Notes
+The committee chair opened the meeting at 6:07 PM with approximately 30 residents in attendance, several of whom spoke during the public comment period.
+
+A representative from the Department of Building and Housing presented a slide deck on the new rental inspection categories. Landlords in attendance questioned the enforcement timeline and the penalty structure for non-compliance.
+
+One resident asked why the weatherization pilot was limited to two neighborhoods when the need is citywide. No answer was given during the meeting.
+
+## Single Signal
+Residents in Slavic Village and Glenville expressed frustration with the pace of housing code enforcement and said they had been waiting years for action.

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,297 @@
+"""Tests for the ingest node: question parsing, gate routing, and graph integration.
+
+parse_questions() is tested directly — it's the new logic this issue adds.
+run_ingest() is tested for gate pass/fail routing.
+The graph integration test confirms ingest populates GraphState correctly.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from documenters_cle_langchain.ingest import IngestedDoc, SkippedDoc, parse_questions, run_ingest
+from documenters_cle_langchain.graph import GraphState, build_graph
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# parse_questions — list format variants
+# ---------------------------------------------------------------------------
+
+def test_numbered_list():
+    blob = "1. How will the community respond?\n2. What happens to closed schools?"
+    result = parse_questions(blob)
+    assert result == [
+        "How will the community respond?",
+        "What happens to closed schools?",
+    ]
+
+
+def test_numbered_list_paren():
+    blob = "1) First question\n2) Second question"
+    result = parse_questions(blob)
+    assert result == ["First question", "Second question"]
+
+
+def test_bulleted_list_dash():
+    blob = "- Why was the vote delayed?\n- Who approved the contract?"
+    result = parse_questions(blob)
+    assert result == ["Why was the vote delayed?", "Who approved the contract?"]
+
+
+def test_bulleted_list_asterisk():
+    blob = "* First question\n* Second question"
+    result = parse_questions(blob)
+    assert result == ["First question", "Second question"]
+
+
+def test_bulleted_list_bullet_char():
+    blob = "• What is the timeline?\n• Who is responsible?"
+    result = parse_questions(blob)
+    assert result == ["What is the timeline?", "Who is responsible?"]
+
+
+def test_bare_lines():
+    blob = "Why did this happen?\nWhat is the next step?\nWho was notified?"
+    result = parse_questions(blob)
+    assert result == [
+        "Why did this happen?",
+        "What is the next step?",
+        "Who was notified?",
+    ]
+
+
+def test_single_line_paragraph():
+    blob = "Why was the public comment period skipped for this contract?"
+    result = parse_questions(blob)
+    assert result == ["Why was the public comment period skipped for this contract?"]
+
+
+def test_empty_blob_returns_empty():
+    assert parse_questions("") == []
+
+
+def test_whitespace_only_returns_empty():
+    assert parse_questions("   \n  \n  ") == []
+
+
+def test_blank_lines_between_questions_skipped():
+    blob = "1. First question\n\n2. Second question\n\n3. Third question"
+    result = parse_questions(blob)
+    assert result == ["First question", "Second question", "Third question"]
+
+
+# ---------------------------------------------------------------------------
+# parse_questions — markdown stripping
+# ---------------------------------------------------------------------------
+
+def test_bold_question_stripped():
+    blob = "**Who decides which neighborhoods are eligible?**"
+    result = parse_questions(blob)
+    assert result == ["Who decides which neighborhoods are eligible?"]
+
+
+def test_italic_question_stripped():
+    blob = "*Why was this decision made without public input?*"
+    result = parse_questions(blob)
+    assert result == ["Why was this decision made without public input?"]
+
+
+def test_bold_in_list():
+    blob = "1. Normal question\n**Bold question?**\n- Bullet question"
+    result = parse_questions(blob)
+    assert result == ["Normal question", "Bold question?", "Bullet question"]
+
+
+# ---------------------------------------------------------------------------
+# parse_questions — hard case fixture
+# ---------------------------------------------------------------------------
+
+def test_mixed_formatting_fixture():
+    """Real-format fixture: numbered + bold + bulleted in same section."""
+    blob = (FIXTURES / "hard_case_note.txt").read_text()
+    # Extract just the follow-up section for this test
+    lines = blob.splitlines()
+    start = next(i for i, l in enumerate(lines) if "Follow-Up Questions" in l)
+    end = next(i for i, l in enumerate(lines) if i > start and l.startswith("##"))
+    section = "\n".join(lines[start + 1:end])
+
+    result = parse_questions(section)
+    assert len(result) == 4
+    assert any("landlords notified" in q for q in result)
+    assert any("weatherization pilot" in q and "funding" in q for q in result)
+    assert any("neighborhoods" in q for q in result)
+    assert any("appeals" in q for q in result)
+
+
+# ---------------------------------------------------------------------------
+# run_ingest — gate routing
+# ---------------------------------------------------------------------------
+
+FULL_DOC = """\
+Ward 10 Community Meeting
+Documenter name: Tommy Oddo
+Agency: Cleveland City Council
+Date: March 4, 2026
+See more about this meeting at Documenters.org
+
+Summary
+Residents raised concerns about public safety.
+
+### Follow-Up Questions
+- How will the community respond?
+- What happens to closed schools?
+
+Notes
+The meeting took place in the rectory of St. Mary's Church.
+
+Single Signal
+Community members are alarmed about recent violence in Collinwood.
+"""
+
+MISSING_AGENCY_DOC = """\
+Some Meeting
+Documenter name: Pat Jones
+Date: March 1, 2026
+See more about this meeting at Documenters.org
+
+Summary
+A brief summary.
+
+Notes
+Some notes here.
+"""
+
+
+def _manifest_doc(doc_id: str, text: str, name: str = "Test Doc") -> dict:
+    return {"doc_id": doc_id, "name": name, "web_url": "", "folder_path": "", "modified_time": "", "text": text}
+
+
+def test_passing_doc_appears_in_ingested():
+    ingested, skipped = run_ingest([_manifest_doc("doc-1", FULL_DOC)])
+    assert len(ingested) == 1
+    assert len(skipped) == 0
+    assert ingested[0]["doc_id"] == "doc-1"
+
+
+def test_failing_doc_appears_in_skipped():
+    ingested, skipped = run_ingest([_manifest_doc("doc-2", MISSING_AGENCY_DOC)])
+    assert len(ingested) == 0
+    assert len(skipped) == 1
+    assert skipped[0]["doc_id"] == "doc-2"
+    assert "agency" in skipped[0]["missing_fields"]
+
+
+def test_mixed_batch_routes_correctly():
+    docs = [
+        _manifest_doc("good", FULL_DOC, "Good Doc"),
+        _manifest_doc("bad", MISSING_AGENCY_DOC, "Bad Doc"),
+    ]
+    ingested, skipped = run_ingest(docs)
+    assert len(ingested) == 1
+    assert len(skipped) == 1
+
+
+def test_empty_manifest_returns_empty():
+    ingested, skipped = run_ingest([])
+    assert ingested == []
+    assert skipped == []
+
+
+def test_questions_are_list_not_blob():
+    ingested, _ = run_ingest([_manifest_doc("doc-1", FULL_DOC)])
+    qs = ingested[0]["follow_up_questions"]
+    assert isinstance(qs, list)
+    assert all(isinstance(q, str) for q in qs)
+
+
+def test_questions_parsed_correctly():
+    ingested, _ = run_ingest([_manifest_doc("doc-1", FULL_DOC)])
+    qs = ingested[0]["follow_up_questions"]
+    assert len(qs) == 2
+    assert "How will the community respond?" in qs
+    assert "What happens to closed schools?" in qs
+
+
+def test_no_follow_up_produces_empty_list():
+    no_followup = """\
+Budget Meeting
+Documenter name: Alex Smith
+Agency: City of Cleveland Urban Forestry Commission
+Date: January 15, 2026
+See more about this meeting at Documenters.org
+
+Summary
+The commission reviewed proposed budget cuts.
+
+Notes
+Meeting was held at City Hall.
+"""
+    ingested, _ = run_ingest([_manifest_doc("doc-1", no_followup)])
+    assert ingested[0]["follow_up_questions"] == []
+
+
+def test_extraction_fields_preserved():
+    ingested, _ = run_ingest([_manifest_doc("doc-1", FULL_DOC)])
+    doc = ingested[0]
+    assert doc["meeting_name"] == "Ward 10 Community Meeting"
+    assert doc["agency"] == "Cleveland City Council"
+    assert doc["date"] == "2026-03-04"
+    assert "public safety" in doc["summary"]
+    assert "Collinwood" in doc["single_signal"]
+
+
+# ---------------------------------------------------------------------------
+# Graph integration — ingest node populates GraphState
+# ---------------------------------------------------------------------------
+
+MINIMAL_STATE: GraphState = {
+    "manifest_docs": [],
+    "sheet_id": None,
+    "run_date": "2026-03-24",
+    "theme_library": [],
+    "prior_decisions": [],
+    "ingested_docs": [],
+    "skipped_docs": [],
+    "retrieval_context": [],
+    "candidates": [],
+    "classified_themes": [],
+    "needs_review": [],
+    "run_summary": {},
+}
+
+
+def test_ingest_node_populates_state():
+    state = {
+        **MINIMAL_STATE,
+        "manifest_docs": [_manifest_doc("doc-1", FULL_DOC, "Ward 10")],
+    }
+    graph = build_graph()
+    result = graph.invoke(state)
+    assert len(result["ingested_docs"]) == 1
+    assert len(result["skipped_docs"]) == 0
+
+
+def test_ingest_node_skips_bad_docs():
+    state = {
+        **MINIMAL_STATE,
+        "manifest_docs": [_manifest_doc("doc-2", MISSING_AGENCY_DOC, "Bad Doc")],
+    }
+    graph = build_graph()
+    result = graph.invoke(state)
+    assert len(result["ingested_docs"]) == 0
+    assert len(result["skipped_docs"]) == 1
+
+
+def test_ingest_node_questions_in_state():
+    state = {
+        **MINIMAL_STATE,
+        "manifest_docs": [_manifest_doc("doc-1", FULL_DOC)],
+    }
+    graph = build_graph()
+    result = graph.invoke(state)
+    qs = result["ingested_docs"][0]["follow_up_questions"]
+    assert isinstance(qs, list)
+    assert len(qs) == 2


### PR DESCRIPTION
## Summary

- Adds `ingest.py`: `IngestedDoc`/`SkippedDoc` TypedDicts, `parse_questions()`, `run_ingest()`
- Implements the `ingest` node in `graph.py` (was a stub)
- Narrows `GraphState.ingested_docs` / `skipped_docs` from `list[Any]` to typed lists
- Adds `tests/fixtures/hard_case_note.txt` — mixed-format fixture note (numbered + bold + bulleted questions)
- 25 new tests; 76 total passing

## Key behavior

`parse_questions()` handles all formatting variants found in real notes:
- Numbered (`1.`, `1)`) and bulleted (`-`, `*`, `•`) lists
- Bare newline-separated lines
- Markdown bold (`**Q?**` → `Q?`)
- Mixed formatting in the same section (the hard case fixture)

Per-line = per question. Multi-line question splitting is not attempted — fragile and not needed for real data.

## Module pattern established

Each substantial node gets its own module. `ingest.py` logic is independently testable without LangGraph or API credentials. `extract_candidates.py` and `classify_themes.py` will follow the same pattern.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)