### PR TITLE
feat: extract_candidates node — LLM theme extraction from questions (#13)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -164,6 +164,45 @@ Six stub nodes: `ingest`, `retrieve_context`, `extract_candidates`, `classify_th
 
 ---
 
+## Issue #13 — extract_candidates node: LLM theme extraction from questions
+
+**Date:** 2026-03-25
+
+**Branch:** `issue-13-extract-candidates-node`
+
+**What was built:**
+
+`extract_candidates.py` — the extract_candidates node implementation and supporting types. One LLM call per follow-up question using `gpt-5.4` with structured output.
+
+`ThemeCandidate` Pydantic model: `{doc_id, source_question, sub_topic, description, retrieved_context}`. The LLM generates only `sub_topic` and `description` via a separate internal `_ExtractedTheme` schema; `doc_id`, `source_question`, and `retrieved_context` are attached from input data, not by the model.
+
+`build_extraction_prompt(question, similar_themes) → list[dict]` — pure function, no LLM call. Retrieved similar themes are formatted as numbered human-readable lines, not raw JSON. Cold-start (no similar themes) produces a message telling the model this may be a new sub-topic.
+
+`run_extract_candidates(retrieval_context, llm)` — accepts the LLM as a parameter (injectable) so tests pass `FakeLLM` without credentials.
+
+`GraphState.candidates` narrowed from `list[Any]` to `list[ThemeCandidate]`.
+
+The `extract_candidates` node in `graph.py` is now a closure that captures `extract_model` from `GraphConfig`. `ChatOpenAI` is instantiated lazily — only when `retrieval_context` is non-empty — so cold-start graph runs don't require `OPENAI_API_KEY`.
+
+29 new tests in `tests/test_extract_candidates.py`. 161 total tests pass, no warnings.
+
+**Key decisions:**
+
+- **One-to-one per the issue recommendation.** One `QuestionContext` → one `ThemeCandidate`. The hard-case test (`test_hard_case_ambiguous_question_produces_single_candidate`) verifies this contract holds for questions spanning two topics — the model is instructed to pick the most specific and actionable one.
+
+- **`retrieved_context: list[dict]` in ThemeCandidate.** The similar themes provided as context are stored verbatim on the candidate so downstream nodes (`classify_themes`, `write_back`) know what evidence the model had. Typed as `list[dict]` rather than `list[SimilarTheme]` to avoid Pydantic/TypedDict interop friction.
+
+- **Prompt separates system role (what a sub-topic IS) from user role (the specific question + context).** System prompt includes concrete examples of specific vs. generic labels so the model understands the level of specificity required. This structure also makes prompt ablation easy — swap the system prompt to test different framing without touching the user template.
+
+- **Graph integration tests updated.** `test_ingest_node_populates_state` and `test_ingest_node_questions_in_state` in `test_ingest.py` were running the full graph and inadvertently triggering LLM calls once `extract_candidates` became real. Fixed by: (a) giving the graph integration test a `NO_QUESTIONS_DOC` fixture (no follow-up questions → empty retrieval_context → LLM never called), (b) changing `test_ingest_node_questions_in_state` to call `run_ingest` directly since question parsing is ingest logic, not graph topology.
+
+**Deferred:**
+
+- Narrative notes as additional context in the extraction prompt. Architecture spec describes narrative notes as "useful context but not the primary signal." Currently the prompt only sees the follow-up question + retrieved similar themes. Whether narrative notes improve sub-topic quality is an open empirical question for LangSmith evaluation after the first real run.
+- One-to-many (one question → multiple candidates). The one-to-one rule is a starting constraint. If LangSmith shows genuine multi-theme questions are systematically collapsing into one muddled candidate, revisit before bootstrapping is complete.
+
+---
+
 ## Issue #12 — retrieve_context node: in-memory vector store and semantic retrieval
 
 **Date:** 2026-03-25

--- a/src/documenters_cle_langchain/extract_candidates.py
+++ b/src/documenters_cle_langchain/extract_candidates.py
@@ -1,0 +1,174 @@
+"""extract_candidates.py — LLM-based theme candidate extraction.
+
+For each follow-up question, produces a ThemeCandidate: proposed sub-topic
+label, description, source question verbatim, and the retrieval context that
+was provided to the model.
+
+One question → one candidate. This is a deliberate starting constraint.
+Genuinely multi-theme questions exist in practice; revisit with LangSmith
+evidence after the first real run before relaxing the one-to-one rule.
+
+Called by the `extract_candidates` node in graph.py.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pydantic import BaseModel
+
+from .retrieve_context import QuestionContext, SimilarTheme
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Output types
+# ---------------------------------------------------------------------------
+
+
+class ThemeCandidate(BaseModel):
+    """A proposed sub-topic theme extracted from a single follow-up question.
+
+    ``sub_topic`` and ``description`` come from the LLM. All other fields
+    are populated by ``run_extract_candidates`` from the input data.
+    """
+
+    doc_id: str
+    source_question: str        # verbatim follow-up question
+    sub_topic: str              # proposed label — specific and lowercase
+    description: str            # 1-2 sentence description of the civic concern
+    retrieved_context: list[dict]  # SimilarTheme dicts shown to the model as context
+
+
+# Internal LLM output schema — only the two fields the model generates.
+# We add doc_id, source_question, and retrieved_context from the input data.
+class _ExtractedTheme(BaseModel):
+    sub_topic: str
+    description: str
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = """\
+You are a civic journalism analyst helping to build a library of recurring \
+themes in Cleveland public meeting notes.
+
+A **sub-topic** is a specific, concrete civic issue or concern — narrow enough \
+to track over time across multiple meetings. Examples:
+  - "Section 8 voucher waitlists" (not "housing")
+  - "Magnet school enrollment caps" (not "education")
+  - "Lead pipe replacement funding" (not "infrastructure")
+  - "Police union contract negotiations" (not "public safety")
+
+Your job: given a follow-up question from a community reporter, propose a \
+single sub-topic label and a 1-2 sentence description of the underlying civic \
+concern. The label should be specific, lowercase, and suitable as a canonical \
+theme name that could recur across meetings."""
+
+USER_PROMPT = """\
+Follow-up question from reporter:
+"{question}"
+
+{context_section}
+
+Propose a single sub-topic label and a 1-2 sentence description for the civic \
+concern expressed in this question. If the question touches multiple issues, \
+choose the most specific and actionable one."""
+
+
+def _format_similar_themes(similar_themes: list[SimilarTheme]) -> str:
+    """Format retrieved similar themes as human-readable context lines."""
+    if not similar_themes:
+        return (
+            "No similar themes found in the library — this may be a new sub-topic."
+        )
+    lines = ["Retrieved similar themes from past meetings:"]
+    for i, t in enumerate(similar_themes, 1):
+        lines.append(
+            f"  {i}. {t['sub_topic']} — {t['description']} ({t['topic']})"
+        )
+    return "\n".join(lines)
+
+
+def build_extraction_prompt(
+    question: str,
+    similar_themes: list[SimilarTheme],
+) -> list[dict]:
+    """Construct prompt messages for a single question extraction.
+
+    Returns a list of message dicts (system + user). Pure function — no LLM
+    call, fully testable without credentials.
+
+    Args:
+        question: the follow-up question text.
+        similar_themes: retrieved similar themes to show as context.
+
+    Returns:
+        ``[{"role": "system", ...}, {"role": "user", ...}]``
+    """
+    context_section = _format_similar_themes(similar_themes)
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": USER_PROMPT.format(
+                question=question,
+                context_section=context_section,
+            ),
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Main runner
+# ---------------------------------------------------------------------------
+
+
+def run_extract_candidates(
+    retrieval_context: list[QuestionContext],
+    llm: Any,  # ChatOpenAI.with_structured_output(_ExtractedTheme), or a test fake
+) -> list[ThemeCandidate]:
+    """Extract one ThemeCandidate per follow-up question.
+
+    One-to-one: each QuestionContext produces exactly one ThemeCandidate.
+    The LLM receives the question text and retrieved similar themes; it returns
+    a sub-topic label and description. Metadata (doc_id, source_question,
+    retrieved_context) is attached by this function, not by the LLM.
+
+    Args:
+        retrieval_context: one QuestionContext per question (from retrieve_context node).
+        llm: a LangChain chat model bound to ``_ExtractedTheme`` structured output,
+             or a compatible test fake with an ``invoke(messages) -> _ExtractedTheme``
+             interface.
+
+    Returns:
+        One ThemeCandidate per entry in retrieval_context, in the same order.
+    """
+    candidates: list[ThemeCandidate] = []
+
+    for ctx in retrieval_context:
+        messages = build_extraction_prompt(ctx["question"], ctx["similar_themes"])
+        extracted: _ExtractedTheme = llm.invoke(messages)
+        candidate = ThemeCandidate(
+            doc_id=ctx["doc_id"],
+            source_question=ctx["question"],
+            sub_topic=extracted.sub_topic,
+            description=extracted.description,
+            retrieved_context=list(ctx["similar_themes"]),
+        )
+        candidates.append(candidate)
+        log.info(
+            "extract_candidates: '%s…' → sub_topic='%s'",
+            ctx["question"][:60],
+            extracted.sub_topic,
+        )
+
+    log.info(
+        "extract_candidates: %d questions → %d candidates",
+        len(retrieval_context),
+        len(candidates),
+    )
+    return candidates

--- a/src/documenters_cle_langchain/graph.py
+++ b/src/documenters_cle_langchain/graph.py
@@ -22,6 +22,7 @@ from langgraph.graph import StateGraph, END
 
 from .ingest import IngestedDoc, SkippedDoc, run_ingest
 from .retrieve_context import QuestionContext, run_retrieve_context
+from .extract_candidates import ThemeCandidate
 
 
 # ---------------------------------------------------------------------------
@@ -82,7 +83,7 @@ class GraphState(TypedDict):
     retrieval_context: list[QuestionContext]  # per-question similar themes from library
 
     # --- extract_candidates output (Issue #13) ---
-    candidates: list[Any]           # list[ThemeCandidate] — proposed sub-topics per question
+    candidates: list[ThemeCandidate]  # proposed sub-topics per question
 
     # --- classify_themes output (Issue #14) ---
     classified_themes: list[Any]    # list[ClassifiedTheme] — merged/new + question type + topic
@@ -115,13 +116,8 @@ def ingest(state: GraphState) -> dict:
 # See _make_retrieve_context_node below.
 
 
-def extract_candidates(state: GraphState) -> dict:
-    """LLM: extract candidate sub-topic themes from follow-up questions.
-
-    Inputs:  ingested_docs, retrieval_context
-    Outputs: candidates
-    """
-    return {}
+# extract_candidates is built as a closure inside build_graph so it can capture
+# the model name from GraphConfig. See build_graph below.
 
 
 def classify_themes(state: GraphState) -> dict:
@@ -170,6 +166,7 @@ def build_graph(config: GraphConfig | None = None) -> Any:
 
     _embedding_model = config.embedding_model
     _retrieval_k = config.retrieval_k
+    _extract_model = config.extract_model
 
     def _retrieve_context(state: GraphState) -> dict:
         """Build in-memory vector store from theme_library; retrieve top-k per question.
@@ -195,11 +192,30 @@ def build_graph(config: GraphConfig | None = None) -> Any:
         )
         return {"retrieval_context": contexts}
 
+    def _extract_candidates(state: GraphState) -> dict:
+        """LLM: extract one ThemeCandidate per follow-up question.
+
+        Inputs:  retrieval_context
+        Outputs: candidates
+
+        ChatOpenAI is instantiated lazily — only when retrieval_context is
+        non-empty — so cold-start runs don't require OPENAI_API_KEY.
+        """
+        if not state["retrieval_context"]:
+            return {"candidates": []}
+
+        from langchain_openai import ChatOpenAI
+        from .extract_candidates import _ExtractedTheme, run_extract_candidates
+
+        llm = ChatOpenAI(model=_extract_model).with_structured_output(_ExtractedTheme)
+        candidates = run_extract_candidates(state["retrieval_context"], llm)
+        return {"candidates": candidates}
+
     graph = StateGraph(GraphState)
 
     graph.add_node("ingest", ingest)
     graph.add_node("retrieve_context", _retrieve_context)
-    graph.add_node("extract_candidates", extract_candidates)
+    graph.add_node("extract_candidates", _extract_candidates)
     graph.add_node("classify_themes", classify_themes)
     graph.add_node("human_review", human_review)
     graph.add_node("write_back", write_back)

--- a/tests/test_extract_candidates.py
+++ b/tests/test_extract_candidates.py
@@ -1,0 +1,338 @@
+"""Tests for extract_candidates.py — prompt construction and candidate extraction.
+
+No real LLM calls. FakeLLM injects preset _ExtractedTheme responses so
+run_extract_candidates can be exercised without OPENAI_API_KEY.
+"""
+from __future__ import annotations
+
+import pytest
+
+from documenters_cle_langchain.extract_candidates import (
+    ThemeCandidate,
+    _ExtractedTheme,
+    _format_similar_themes,
+    build_extraction_prompt,
+    run_extract_candidates,
+)
+from documenters_cle_langchain.retrieve_context import QuestionContext, SimilarTheme
+
+
+# ---------------------------------------------------------------------------
+# Fake LLM — returns a preset _ExtractedTheme without any API call
+# ---------------------------------------------------------------------------
+
+
+class FakeLLM:
+    """Minimal fake that satisfies the llm.invoke(messages) interface."""
+
+    def __init__(self, response: _ExtractedTheme):
+        self.response = response
+        self.calls: list[list[dict]] = []  # capture inputs for assertion
+
+    def invoke(self, messages: list[dict]) -> _ExtractedTheme:
+        self.calls.append(messages)
+        return self.response
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def make_similar_theme(sub_topic: str, description: str, topic: str = "HOUSING") -> SimilarTheme:
+    return SimilarTheme(
+        sub_topic=sub_topic,
+        description=description,
+        topic=topic,
+        similarity_score=0.85,
+    )
+
+
+def make_context(
+    doc_id: str,
+    question: str,
+    similar_themes: list[SimilarTheme] | None = None,
+) -> QuestionContext:
+    return QuestionContext(
+        doc_id=doc_id,
+        question=question,
+        similar_themes=similar_themes or [],
+        venue_context=[],
+    )
+
+
+HOUSING_THEME = make_similar_theme(
+    "Section 8 voucher waitlists",
+    "Long waits for housing assistance vouchers",
+    "HOUSING",
+)
+EDUCATION_THEME = make_similar_theme(
+    "Magnet school enrollment caps",
+    "Limits on enrollment at magnet schools",
+    "EDUCATION",
+)
+
+DEFAULT_RESPONSE = _ExtractedTheme(
+    sub_topic="Section 8 voucher waitlists",
+    description="Community members face long waits for housing vouchers.",
+)
+
+# ---------------------------------------------------------------------------
+# _format_similar_themes
+# ---------------------------------------------------------------------------
+
+
+def test_format_similar_themes_empty_returns_cold_start_message():
+    result = _format_similar_themes([])
+    assert "new sub-topic" in result.lower()
+
+
+def test_format_similar_themes_includes_sub_topic():
+    result = _format_similar_themes([HOUSING_THEME])
+    assert "Section 8 voucher waitlists" in result
+
+
+def test_format_similar_themes_includes_description():
+    result = _format_similar_themes([HOUSING_THEME])
+    assert "Long waits for housing assistance vouchers" in result
+
+
+def test_format_similar_themes_includes_topic():
+    result = _format_similar_themes([HOUSING_THEME])
+    assert "HOUSING" in result
+
+
+def test_format_similar_themes_multiple_numbered():
+    result = _format_similar_themes([HOUSING_THEME, EDUCATION_THEME])
+    assert "1." in result
+    assert "2." in result
+
+
+# ---------------------------------------------------------------------------
+# build_extraction_prompt — structure
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_has_two_messages():
+    messages = build_extraction_prompt("What about housing?", [])
+    assert len(messages) == 2
+
+
+def test_prompt_first_message_is_system():
+    messages = build_extraction_prompt("What about housing?", [])
+    assert messages[0]["role"] == "system"
+
+
+def test_prompt_second_message_is_user():
+    messages = build_extraction_prompt("What about housing?", [])
+    assert messages[1]["role"] == "user"
+
+
+def test_prompt_system_defines_sub_topic():
+    messages = build_extraction_prompt("What about housing?", [])
+    assert "sub-topic" in messages[0]["content"].lower()
+
+
+def test_prompt_system_includes_examples():
+    """System prompt must include concrete examples so the model understands specificity."""
+    messages = build_extraction_prompt("What about housing?", [])
+    # At least one of the canonical examples should appear
+    assert any(
+        example in messages[0]["content"]
+        for example in ["Section 8", "enrollment caps", "Lead pipe"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_extraction_prompt — question and context content
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_contains_question_text():
+    question = "Why is the waitlist for housing vouchers so long?"
+    messages = build_extraction_prompt(question, [])
+    assert question in messages[1]["content"]
+
+
+def test_prompt_contains_retrieved_theme_label():
+    messages = build_extraction_prompt("housing question", [HOUSING_THEME])
+    assert "Section 8 voucher waitlists" in messages[1]["content"]
+
+
+def test_prompt_contains_retrieved_theme_topic():
+    messages = build_extraction_prompt("housing question", [HOUSING_THEME])
+    assert "HOUSING" in messages[1]["content"]
+
+
+def test_prompt_cold_start_message_present():
+    messages = build_extraction_prompt("housing question", [])
+    assert "new sub-topic" in messages[1]["content"].lower()
+
+
+def test_prompt_multiple_themes_all_appear():
+    messages = build_extraction_prompt("question", [HOUSING_THEME, EDUCATION_THEME])
+    content = messages[1]["content"]
+    assert "Section 8 voucher waitlists" in content
+    assert "Magnet school enrollment caps" in content
+
+
+# ---------------------------------------------------------------------------
+# run_extract_candidates — empty / cold start
+# ---------------------------------------------------------------------------
+
+
+def test_empty_retrieval_context_returns_empty_candidates():
+    llm = FakeLLM(DEFAULT_RESPONSE)
+    candidates = run_extract_candidates([], llm)
+    assert candidates == []
+    assert llm.calls == []  # LLM never called
+
+
+# ---------------------------------------------------------------------------
+# run_extract_candidates — one-to-one contract
+# ---------------------------------------------------------------------------
+
+
+def test_one_candidate_per_question():
+    contexts = [
+        make_context("doc1", "Question one?"),
+        make_context("doc1", "Question two?"),
+        make_context("doc2", "Question three?"),
+    ]
+    llm = FakeLLM(DEFAULT_RESPONSE)
+    candidates = run_extract_candidates(contexts, llm)
+    assert len(candidates) == 3
+
+
+def test_llm_called_once_per_question():
+    contexts = [
+        make_context("doc1", "Q1?"),
+        make_context("doc1", "Q2?"),
+    ]
+    llm = FakeLLM(DEFAULT_RESPONSE)
+    run_extract_candidates(contexts, llm)
+    assert len(llm.calls) == 2
+
+
+def test_candidate_order_matches_context_order():
+    responses = [
+        _ExtractedTheme(sub_topic="first theme", description="first"),
+        _ExtractedTheme(sub_topic="second theme", description="second"),
+    ]
+
+    class SequentialFakeLLM:
+        def __init__(self):
+            self._idx = 0
+
+        def invoke(self, messages):
+            resp = responses[self._idx]
+            self._idx += 1
+            return resp
+
+    contexts = [
+        make_context("doc1", "Q1?"),
+        make_context("doc1", "Q2?"),
+    ]
+    candidates = run_extract_candidates(contexts, SequentialFakeLLM())
+    assert candidates[0].sub_topic == "first theme"
+    assert candidates[1].sub_topic == "second theme"
+
+
+# ---------------------------------------------------------------------------
+# run_extract_candidates — ThemeCandidate field population
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_doc_id_preserved():
+    ctx = make_context("abc-123", "Question?")
+    candidates = run_extract_candidates([ctx], FakeLLM(DEFAULT_RESPONSE))
+    assert candidates[0].doc_id == "abc-123"
+
+
+def test_candidate_source_question_preserved():
+    question = "Why is the voucher waitlist so long?"
+    ctx = make_context("doc1", question)
+    candidates = run_extract_candidates([ctx], FakeLLM(DEFAULT_RESPONSE))
+    assert candidates[0].source_question == question
+
+
+def test_candidate_sub_topic_from_llm():
+    response = _ExtractedTheme(sub_topic="lead pipe replacement", description="desc")
+    ctx = make_context("doc1", "Question?")
+    candidates = run_extract_candidates([ctx], FakeLLM(response))
+    assert candidates[0].sub_topic == "lead pipe replacement"
+
+
+def test_candidate_description_from_llm():
+    response = _ExtractedTheme(sub_topic="label", description="Custom description text.")
+    ctx = make_context("doc1", "Question?")
+    candidates = run_extract_candidates([ctx], FakeLLM(response))
+    assert candidates[0].description == "Custom description text."
+
+
+def test_candidate_retrieved_context_preserved():
+    ctx = make_context("doc1", "Question?", similar_themes=[HOUSING_THEME])
+    candidates = run_extract_candidates([ctx], FakeLLM(DEFAULT_RESPONSE))
+    assert len(candidates[0].retrieved_context) == 1
+    assert candidates[0].retrieved_context[0]["sub_topic"] == "Section 8 voucher waitlists"
+
+
+def test_candidate_retrieved_context_empty_on_cold_start():
+    ctx = make_context("doc1", "Question?", similar_themes=[])
+    candidates = run_extract_candidates([ctx], FakeLLM(DEFAULT_RESPONSE))
+    assert candidates[0].retrieved_context == []
+
+
+def test_candidate_is_theme_candidate_instance():
+    ctx = make_context("doc1", "Question?")
+    candidates = run_extract_candidates([ctx], FakeLLM(DEFAULT_RESPONSE))
+    assert isinstance(candidates[0], ThemeCandidate)
+
+
+# ---------------------------------------------------------------------------
+# Hard case — ambiguous question spanning two sub-topics
+# ---------------------------------------------------------------------------
+
+AMBIGUOUS_QUESTION = (
+    "How does the shortage of Section 8 vouchers affect where families can afford "
+    "to live, and does that limit which schools their kids can attend?"
+)
+
+
+def test_hard_case_ambiguous_question_produces_single_candidate():
+    """A question spanning housing and education must produce exactly one candidate.
+
+    The one-to-one contract must hold regardless of question complexity.
+    The model is expected to pick the most specific and actionable sub-topic.
+    """
+    response = _ExtractedTheme(
+        sub_topic="housing voucher impact on school access",
+        description=(
+            "Shortage of housing vouchers constrains where families can live, "
+            "limiting their children's school options."
+        ),
+    )
+    ctx = make_context(
+        "doc1",
+        AMBIGUOUS_QUESTION,
+        similar_themes=[HOUSING_THEME, EDUCATION_THEME],
+    )
+    candidates = run_extract_candidates([ctx], FakeLLM(response))
+    assert len(candidates) == 1
+
+
+def test_hard_case_source_question_preserved_verbatim():
+    """The verbatim question is stored even for multi-topic edge cases."""
+    ctx = make_context("doc1", AMBIGUOUS_QUESTION)
+    candidates = run_extract_candidates([ctx], FakeLLM(DEFAULT_RESPONSE))
+    assert candidates[0].source_question == AMBIGUOUS_QUESTION
+
+
+def test_hard_case_prompt_includes_both_retrieved_themes():
+    """Both retrieved themes appear in the prompt so the model has full context."""
+    messages = build_extraction_prompt(
+        AMBIGUOUS_QUESTION, [HOUSING_THEME, EDUCATION_THEME]
+    )
+    content = messages[1]["content"]
+    assert "Section 8 voucher waitlists" in content
+    assert "Magnet school enrollment caps" in content

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -245,7 +245,35 @@ def test_extraction_fields_preserved():
 
 # ---------------------------------------------------------------------------
 # Graph integration — ingest node populates GraphState
+#
+# These tests invoke the full graph but use a document WITHOUT follow-up
+# questions so that retrieval_context stays empty and extract_candidates
+# short-circuits without making any LLM calls. This keeps the graph
+# integration tests runnable without OPENAI_API_KEY.
+#
+# Question-parsing behavior is tested directly via run_ingest above; it does
+# not need the full graph to be exercised.
 # ---------------------------------------------------------------------------
+
+# All required fields present, but no follow-up questions section.
+# Omitting the section entirely produces an empty questions list, keeping
+# retrieval_context empty so extract_candidates never fires the LLM.
+NO_QUESTIONS_DOC = """\
+Ward 10 Community Meeting
+Documenter name: Tommy Oddo
+Agency: Cleveland City Council
+Date: March 4, 2026
+See more about this meeting at Documenters.org
+
+Summary
+Residents raised concerns about public safety.
+
+Notes
+The meeting took place in the rectory of St. Mary's Church.
+
+Single Signal
+Community members are alarmed about recent violence in Collinwood.
+"""
 
 MINIMAL_STATE: GraphState = {
     "manifest_docs": [],
@@ -266,7 +294,7 @@ MINIMAL_STATE: GraphState = {
 def test_ingest_node_populates_state():
     state = {
         **MINIMAL_STATE,
-        "manifest_docs": [_manifest_doc("doc-1", FULL_DOC, "Ward 10")],
+        "manifest_docs": [_manifest_doc("doc-1", NO_QUESTIONS_DOC, "Ward 10")],
     }
     graph = build_graph()
     result = graph.invoke(state)
@@ -286,12 +314,9 @@ def test_ingest_node_skips_bad_docs():
 
 
 def test_ingest_node_questions_in_state():
-    state = {
-        **MINIMAL_STATE,
-        "manifest_docs": [_manifest_doc("doc-1", FULL_DOC)],
-    }
-    graph = build_graph()
-    result = graph.invoke(state)
-    qs = result["ingested_docs"][0]["follow_up_questions"]
+    # Question parsing is ingest logic, not graph topology — test via run_ingest
+    # directly to avoid triggering downstream LLM nodes.
+    ingested, _ = run_ingest([_manifest_doc("doc-1", FULL_DOC)])
+    qs = ingested[0]["follow_up_questions"]
     assert isinstance(qs, list)
     assert len(qs) == 2


### PR DESCRIPTION
## Summary

- Adds `extract_candidates.py` with `ThemeCandidate`, `build_extraction_prompt`, and `run_extract_candidates`
- Retrieved similar themes are formatted as human-readable numbered lines in the prompt (not raw JSON)
- Lazy `ChatOpenAI` in graph closure — cold-start runs and tests need no `OPENAI_API_KEY`
- `GraphState.candidates` narrowed from `list[Any]` to `list[ThemeCandidate]`
- Graph integration tests in `test_ingest.py` updated to avoid triggering LLM calls (introduced a `NO_QUESTIONS_DOC` fixture)
- 29 new tests; 161 total passing, no warnings

## Test plan

- [x] `uv run pytest tests/test_extract_candidates.py -v` — 29 tests pass
- [x] `uv run pytest` — all 161 tests pass, no warnings
- [x] Review `SYSTEM_PROMPT` in `extract_candidates.py` — does the definition of "sub-topic" and the examples give the model the right framing?
- [x] Review `USER_PROMPT` — is the instruction to "choose the most specific and actionable" right for the ambiguous-question case?
- [x] Cold-start graph test still passes without `OPENAI_API_KEY` (empty `theme_library` + no questions)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)