### PR TITLE
feat: classify_themes node — merge/split, question type, topic assignment (#14)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -164,6 +164,53 @@ Six stub nodes: `ingest`, `retrieve_context`, `extract_candidates`, `classify_th
 
 ---
 
+## Issue #14 — classify_themes node: merge/split, question type, topic assignment
+
+**Date:** 2026-03-25
+
+**Branch:** `issue-14-classify-themes-node`
+
+**What was built:**
+
+`classify_themes.py` — the classify_themes node implementation. Two LLM calls per candidate, three inferences total.
+
+`_MergeSplitDecision` internal schema: `{decision, matched_theme, confidence, reasoning}`. Used with `classify_model` (gpt-5.4).
+
+`_QuestionTypeAndTopic` internal schema: `{question_type, question_type_confidence, low_confidence, proposed_new_type, topic}`. Used with `question_type_model`. Combines question type and national topic in one call — both are more mechanical than merge/split and don't confuse the model when combined.
+
+`ClassifiedTheme` Pydantic model: the full output type. Carries merge/split decision, confidence, reasoning, `needs_review` flag, question type (with low-confidence and proposed-new-type flags), and national topic. `question_type="uncertain"` is normalised to `None`.
+
+`build_merge_split_prompt(candidate) → list[dict]` — pure function. Formats retrieved similar themes as numbered lines. System prompt instructs model to lean NEW when uncertain — easier for editors to merge later than to split.
+
+`build_question_type_prompt(candidate) → list[dict]` — pure function. Shows the full 5-label taxonomy with definitions. Also shows all 20 national topic labels for the constrained lookup. Both `low_confidence` and `proposed_new_type` fields are explained in the system prompt so the model knows to use them rather than forcing a pick.
+
+`classify_one(candidate, merge_llm, qt_llm, review_threshold) → ClassifiedTheme` — runs both inferences and assembles the result.
+
+`run_classify_themes(candidates, merge_llm, qt_llm, review_threshold) → (list[ClassifiedTheme], list[ClassifiedTheme])` — classifies all candidates, returns the full list and the `needs_review` subset.
+
+`GraphState.classified_themes` and `GraphState.needs_review` narrowed from `list[Any]` to `list[ClassifiedTheme]`.
+
+39 new tests in `tests/test_classify_themes.py`. 200 total tests pass, no warnings.
+
+**Key decisions:**
+
+- **Two LLM calls, not three.** Merge/split gets its own call on `classify_model` — it's the hard judgment and should stay focused. Question type + topic are combined in a second call on `question_type_model` — both are more constrained, and topic assignment is "a constrained lookup, not open inference" per the architecture spec. Combining them doesn't degrade quality and halves the number of API calls.
+
+- **"Lean NEW when uncertain."** The merge/split system prompt explicitly instructs the model to prefer NEW when confidence is low. The reasoning: incorrect merges corrupt the Theme Library in compounding ways (a bad merge in run 1 becomes a misleading retrieval result in run 2). Incorrect splits are surfaced to editors for easy correction. This asymmetry justifies the bias.
+
+- **`question_type="uncertain"` normalised to `None`.** The model can return "uncertain" when no label fits. Rather than storing that string in `ClassifiedTheme.question_type` (which downstream code would need to handle as a special case), it's normalised to `None`. The `proposed_new_question_type` field carries the model's description if it proposed an alternative.
+
+- **`needs_review` is `confidence < threshold`, exclusive lower bound.** Confidence exactly at threshold (e.g., 0.40 with a 0.40 threshold) is NOT flagged. This matches the intent: the threshold is a floor below which we're uncertain, not a ceiling above which we're confident.
+
+- **Lazy LLM construction in graph node.** Same pattern as #12 and #13 — `ChatOpenAI` instantiated only when `candidates` is non-empty, so cold-start and test graph invocations don't require `OPENAI_API_KEY`.
+
+**Deferred:**
+
+- Question type retrieval context. Issue #14 documents the hypothesis: "no retrieval needed for question type; taxonomy is stable enough to classify from the question alone." LangSmith will confirm.
+- Confidence threshold calibration. Starting at 0.4 per the issue; to be tuned after bootstrapping runs.
+
+---
+
 ## Issue #13 — extract_candidates node: LLM theme extraction from questions
 
 **Date:** 2026-03-25

--- a/src/documenters_cle_langchain/classify_themes.py
+++ b/src/documenters_cle_langchain/classify_themes.py
@@ -1,0 +1,320 @@
+"""classify_themes.py — Two-inference LLM classification of theme candidates.
+
+For each ThemeCandidate, makes two independent LLM calls:
+
+1. **Merge/split** (classify_model — gpt-5.4): Is this candidate a variant of
+   an existing theme in the library (merge) or genuinely new (new)? This is
+   the hard judgment step and uses the frontier model. Borderline cases below
+   ``review_confidence_threshold`` are marked ``needs_review=True``.
+
+2. **Question type + topic** (question_type_model): Assign one of the five
+   epistemic posture labels (or flag low confidence / propose a new type).
+   Also assigns the national topic from the 20-topic taxonomy — a constrained
+   lookup, not open inference.
+
+The two calls are independent by design. Question type doesn't require
+retrieval context; topic assignment is deterministic enough that it can share
+a call with question type without confusing the model.
+
+Called by the ``classify_themes`` node in graph.py.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from .extract_candidates import ThemeCandidate
+from .retrieve_context import SimilarTheme
+from .theme_library import QuestionType, Topic
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Taxonomy reference strings (built once from the enums)
+# ---------------------------------------------------------------------------
+
+_QUESTION_TYPE_DEFS = """\
+- knowledge_gap: reporter doesn't understand how a process or program works
+- process_confusion: reporter doesn't understand how a decision is made or who has authority
+- skepticism: a challenge or critique framed as a question, grounded in lived community experience
+- accountability: something was promised or required and hasn't happened; asking for follow-through
+- continuity: a prior thread hasn't been picked up; reporter is asking what happened next"""
+
+_TOPIC_LIST = "\n".join(f"- {t.value}" for t in Topic)
+
+
+# ---------------------------------------------------------------------------
+# Internal LLM output schemas
+# ---------------------------------------------------------------------------
+
+
+class _MergeSplitDecision(BaseModel):
+    """Structured output for the merge/split inference."""
+
+    decision: Literal["merge", "new"]
+    matched_theme: str | None   # canonical sub_topic of the existing theme if merge
+    confidence: float           # 0.0–1.0
+    reasoning: str              # brief explanation; shown in LangSmith trace
+
+
+class _QuestionTypeAndTopic(BaseModel):
+    """Structured output for the combined question-type + topic inference."""
+
+    question_type: str          # one of the 5 taxonomy labels, or "uncertain"
+    question_type_confidence: float  # 0.0–1.0
+    low_confidence: bool        # True if model flags genuine uncertainty
+    proposed_new_type: str | None   # if no existing label fits, describe the new category
+    topic: str                  # one of the 20 national taxonomy values
+
+
+# ---------------------------------------------------------------------------
+# ClassifiedTheme — the public output type for this node
+# ---------------------------------------------------------------------------
+
+
+class ClassifiedTheme(BaseModel):
+    """A fully classified theme candidate.
+
+    Combines the original ThemeCandidate fields with the results of two
+    independent LLM inferences: merge/split and question type + topic.
+
+    ``needs_review`` is True when merge_confidence is below the configured
+    threshold — these rows are written to the classified notes tab with the
+    Decision column left blank for reporter input.
+    """
+
+    # Preserved from ThemeCandidate
+    doc_id: str
+    source_question: str
+    sub_topic: str          # candidate's proposed label (canonical if merge)
+    description: str
+    retrieved_context: list[dict]
+
+    # Merge/split inference
+    decision: Literal["merge", "new"]
+    matched_theme: str | None   # existing theme's sub_topic if decision=="merge"
+    merge_confidence: float
+    merge_reasoning: str
+    needs_review: bool          # True if merge_confidence < review_confidence_threshold
+
+    # Question type inference
+    question_type: str | None       # None when question_type == "uncertain"
+    question_type_confidence: float
+    question_type_low_confidence: bool
+    proposed_new_question_type: str | None
+
+    # Topic inference
+    topic: str                      # national taxonomy value (e.g. "HOUSING")
+
+
+# ---------------------------------------------------------------------------
+# Prompt construction — pure functions, testable without credentials
+# ---------------------------------------------------------------------------
+
+_MERGE_SPLIT_SYSTEM = """\
+You are classifying whether a proposed civic theme is a variant of an existing \
+theme in the Theme Library, or a genuinely new theme.
+
+MERGE: The candidate expresses the same underlying civic concern as an existing \
+theme, even if the wording or framing differs. Examples that should merge:
+  - "affordable housing voucher delays" → "Section 8 voucher waitlists"
+  - "waiting list for rental assistance" → "Section 8 voucher waitlists"
+
+NEW: The candidate expresses a civic concern that is distinct from all retrieved \
+themes — a different issue, not just a different phrasing.
+
+When in doubt, lean toward NEW. It is easier for editors to merge themes later \
+than to split a theme that was incorrectly merged."""
+
+_MERGE_SPLIT_USER = """\
+Candidate theme: "{sub_topic}"
+Description: "{description}"
+
+{retrieved_section}
+
+Is this candidate a MERGE with an existing theme, or a NEW theme?
+Provide a confidence score (0.0–1.0) and a brief reasoning sentence.
+For MERGE, name the existing theme it should merge into (use its exact label)."""
+
+_QT_SYSTEM = """\
+You are classifying the epistemic posture of a community reporter's follow-up \
+question from a public meeting, and assigning a civic topic category.
+
+**Question type taxonomy:**
+{question_type_defs}
+
+These categories can blur in practice — skepticism shades into accountability, \
+continuity into accountability. If you are genuinely uncertain between two types, \
+set low_confidence=True and pick the closest one. If the question doesn't fit \
+any existing category, set proposed_new_type to a short description of what \
+new category would fit.
+
+**National topic taxonomy** (pick the single best match):
+{topic_list}"""
+
+_QT_USER = """\
+Follow-up question: "{question}"
+Proposed sub-topic: "{sub_topic}"
+
+Assign a question type and the best-matching national topic."""
+
+
+def _format_retrieved_themes(similar_themes: list[SimilarTheme]) -> str:
+    if not similar_themes:
+        return "No similar themes found in the library — this may be a new theme."
+    lines = ["Retrieved similar themes from the library:"]
+    for i, t in enumerate(similar_themes, 1):
+        lines.append(f"  {i}. {t['sub_topic']} — {t['description']} ({t['topic']})")
+    return "\n".join(lines)
+
+
+def build_merge_split_prompt(candidate: ThemeCandidate) -> list[dict]:
+    """Construct merge/split prompt messages for a single candidate.
+
+    Pure function — no LLM call, fully testable without credentials.
+    """
+    retrieved_section = _format_retrieved_themes(
+        [SimilarTheme(**t) for t in candidate.retrieved_context]
+        if candidate.retrieved_context
+        else []
+    )
+    return [
+        {"role": "system", "content": _MERGE_SPLIT_SYSTEM},
+        {
+            "role": "user",
+            "content": _MERGE_SPLIT_USER.format(
+                sub_topic=candidate.sub_topic,
+                description=candidate.description,
+                retrieved_section=retrieved_section,
+            ),
+        },
+    ]
+
+
+def build_question_type_prompt(candidate: ThemeCandidate) -> list[dict]:
+    """Construct question-type + topic prompt messages for a single candidate.
+
+    Pure function — no LLM call, fully testable without credentials.
+    """
+    return [
+        {
+            "role": "system",
+            "content": _QT_SYSTEM.format(
+                question_type_defs=_QUESTION_TYPE_DEFS,
+                topic_list=_TOPIC_LIST,
+            ),
+        },
+        {
+            "role": "user",
+            "content": _QT_USER.format(
+                question=candidate.source_question,
+                sub_topic=candidate.sub_topic,
+            ),
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Per-candidate classification
+# ---------------------------------------------------------------------------
+
+
+def classify_one(
+    candidate: ThemeCandidate,
+    merge_llm: Any,
+    qt_llm: Any,
+    review_threshold: float,
+) -> ClassifiedTheme:
+    """Run both inferences on a single candidate and return a ClassifiedTheme.
+
+    Args:
+        candidate: the ThemeCandidate to classify.
+        merge_llm: LLM bound to ``_MergeSplitDecision`` structured output.
+        qt_llm: LLM bound to ``_QuestionTypeAndTopic`` structured output.
+        review_threshold: merge_confidence below this → needs_review=True.
+    """
+    # Inference 1: merge/split
+    merge_messages = build_merge_split_prompt(candidate)
+    merge_dec: _MergeSplitDecision = merge_llm.invoke(merge_messages)
+
+    # Inference 2: question type + topic
+    qt_messages = build_question_type_prompt(candidate)
+    qt_dec: _QuestionTypeAndTopic = qt_llm.invoke(qt_messages)
+
+    needs_review = merge_dec.confidence < review_threshold
+
+    # Normalise question type: treat "uncertain" as None
+    qt_value = (
+        None
+        if qt_dec.question_type.lower() == "uncertain"
+        else qt_dec.question_type
+    )
+
+    classified = ClassifiedTheme(
+        doc_id=candidate.doc_id,
+        source_question=candidate.source_question,
+        sub_topic=candidate.sub_topic,
+        description=candidate.description,
+        retrieved_context=candidate.retrieved_context,
+        decision=merge_dec.decision,
+        matched_theme=merge_dec.matched_theme,
+        merge_confidence=merge_dec.confidence,
+        merge_reasoning=merge_dec.reasoning,
+        needs_review=needs_review,
+        question_type=qt_value,
+        question_type_confidence=qt_dec.question_type_confidence,
+        question_type_low_confidence=qt_dec.low_confidence,
+        proposed_new_question_type=qt_dec.proposed_new_type,
+        topic=qt_dec.topic,
+    )
+
+    log.info(
+        "classify: '%s' → %s (conf=%.2f%s) | qt=%s | topic=%s",
+        candidate.sub_topic,
+        merge_dec.decision,
+        merge_dec.confidence,
+        " REVIEW" if needs_review else "",
+        qt_value or "uncertain",
+        qt_dec.topic,
+    )
+    return classified
+
+
+# ---------------------------------------------------------------------------
+# Main runner
+# ---------------------------------------------------------------------------
+
+
+def run_classify_themes(
+    candidates: list[ThemeCandidate],
+    merge_llm: Any,
+    qt_llm: Any,
+    review_threshold: float,
+) -> tuple[list[ClassifiedTheme], list[ClassifiedTheme]]:
+    """Classify all candidates and split into full list and needs-review subset.
+
+    Args:
+        candidates: ThemeCandidates from extract_candidates node.
+        merge_llm: LLM bound to ``_MergeSplitDecision`` structured output.
+        qt_llm: LLM bound to ``_QuestionTypeAndTopic`` structured output.
+        review_threshold: merge_confidence below this → needs_review=True.
+
+    Returns:
+        ``(classified_themes, needs_review)`` — all results, and the subset
+        with ``needs_review=True`` for easy state population.
+    """
+    classified: list[ClassifiedTheme] = []
+    for candidate in candidates:
+        classified.append(classify_one(candidate, merge_llm, qt_llm, review_threshold))
+
+    needs_review = [c for c in classified if c.needs_review]
+
+    log.info(
+        "classify_themes: %d candidates → %d classified, %d flagged for review",
+        len(candidates),
+        len(classified),
+        len(needs_review),
+    )
+    return classified, needs_review

--- a/src/documenters_cle_langchain/graph.py
+++ b/src/documenters_cle_langchain/graph.py
@@ -23,6 +23,7 @@ from langgraph.graph import StateGraph, END
 from .ingest import IngestedDoc, SkippedDoc, run_ingest
 from .retrieve_context import QuestionContext, run_retrieve_context
 from .extract_candidates import ThemeCandidate
+from .classify_themes import ClassifiedTheme
 
 
 # ---------------------------------------------------------------------------
@@ -86,8 +87,8 @@ class GraphState(TypedDict):
     candidates: list[ThemeCandidate]  # proposed sub-topics per question
 
     # --- classify_themes output (Issue #14) ---
-    classified_themes: list[Any]    # list[ClassifiedTheme] — merged/new + question type + topic
-    needs_review: list[Any]         # subset of classified_themes flagged for human review
+    classified_themes: list[ClassifiedTheme]  # merged/new + question type + topic
+    needs_review: list[ClassifiedTheme]       # subset flagged for human review
 
     # --- run summary, populated by write_back ---
     run_summary: dict               # counts, error list, and any run-level diagnostics
@@ -120,13 +121,8 @@ def ingest(state: GraphState) -> dict:
 # the model name from GraphConfig. See build_graph below.
 
 
-def classify_themes(state: GraphState) -> dict:
-    """LLM: merge/split decision, question type, national topic assignment.
-
-    Inputs:  candidates, retrieval_context
-    Outputs: classified_themes, needs_review
-    """
-    return {}
+# classify_themes is built as a closure inside build_graph so it can capture
+# model names and the review threshold from GraphConfig. See build_graph below.
 
 
 def human_review(state: GraphState) -> dict:
@@ -167,6 +163,9 @@ def build_graph(config: GraphConfig | None = None) -> Any:
     _embedding_model = config.embedding_model
     _retrieval_k = config.retrieval_k
     _extract_model = config.extract_model
+    _classify_model = config.classify_model
+    _question_type_model = config.question_type_model
+    _review_threshold = config.review_confidence_threshold
 
     def _retrieve_context(state: GraphState) -> dict:
         """Build in-memory vector store from theme_library; retrieve top-k per question.
@@ -211,12 +210,42 @@ def build_graph(config: GraphConfig | None = None) -> Any:
         candidates = run_extract_candidates(state["retrieval_context"], llm)
         return {"candidates": candidates}
 
+    def _classify_themes(state: GraphState) -> dict:
+        """LLM: merge/split decision, question type, national topic assignment.
+
+        Inputs:  candidates
+        Outputs: classified_themes, needs_review
+
+        Two ChatOpenAI instances are created lazily — only when candidates is
+        non-empty — so cold-start runs don't require OPENAI_API_KEY.
+        """
+        if not state["candidates"]:
+            return {"classified_themes": [], "needs_review": []}
+
+        from langchain_openai import ChatOpenAI
+        from .classify_themes import (
+            _MergeSplitDecision,
+            _QuestionTypeAndTopic,
+            run_classify_themes,
+        )
+
+        merge_llm = ChatOpenAI(model=_classify_model).with_structured_output(
+            _MergeSplitDecision
+        )
+        qt_llm = ChatOpenAI(model=_question_type_model).with_structured_output(
+            _QuestionTypeAndTopic
+        )
+        classified, needs_review = run_classify_themes(
+            state["candidates"], merge_llm, qt_llm, _review_threshold
+        )
+        return {"classified_themes": classified, "needs_review": needs_review}
+
     graph = StateGraph(GraphState)
 
     graph.add_node("ingest", ingest)
     graph.add_node("retrieve_context", _retrieve_context)
     graph.add_node("extract_candidates", _extract_candidates)
-    graph.add_node("classify_themes", classify_themes)
+    graph.add_node("classify_themes", _classify_themes)
     graph.add_node("human_review", human_review)
     graph.add_node("write_back", write_back)
 

--- a/tests/test_classify_themes.py
+++ b/tests/test_classify_themes.py
@@ -1,0 +1,550 @@
+"""Tests for classify_themes.py — prompt construction and classification logic.
+
+No real LLM calls. FakeMergeLLM and FakeQTLLM inject preset responses so
+all business logic is exercised without OPENAI_API_KEY.
+"""
+from __future__ import annotations
+
+import pytest
+
+from documenters_cle_langchain.classify_themes import (
+    ClassifiedTheme,
+    _MergeSplitDecision,
+    _QuestionTypeAndTopic,
+    _QUESTION_TYPE_DEFS,
+    _TOPIC_LIST,
+    build_merge_split_prompt,
+    build_question_type_prompt,
+    classify_one,
+    run_classify_themes,
+)
+from documenters_cle_langchain.extract_candidates import ThemeCandidate
+from documenters_cle_langchain.theme_library import QuestionType, Topic
+
+
+# ---------------------------------------------------------------------------
+# Fake LLMs
+# ---------------------------------------------------------------------------
+
+
+class FakeMergeLLM:
+    def __init__(self, response: _MergeSplitDecision):
+        self.response = response
+        self.calls: list[list[dict]] = []
+
+    def invoke(self, messages: list[dict]) -> _MergeSplitDecision:
+        self.calls.append(messages)
+        return self.response
+
+
+class FakeQTLLM:
+    def __init__(self, response: _QuestionTypeAndTopic):
+        self.response = response
+        self.calls: list[list[dict]] = []
+
+    def invoke(self, messages: list[dict]) -> _QuestionTypeAndTopic:
+        self.calls.append(messages)
+        return self.response
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+DEFAULT_MERGE_RESPONSE = _MergeSplitDecision(
+    decision="new",
+    matched_theme=None,
+    confidence=0.85,
+    reasoning="No similar theme found; this is a distinct civic concern.",
+)
+
+DEFAULT_QT_RESPONSE = _QuestionTypeAndTopic(
+    question_type="knowledge_gap",
+    question_type_confidence=0.82,
+    low_confidence=False,
+    proposed_new_type=None,
+    topic="HOUSING",
+)
+
+HOUSING_SIMILAR = {
+    "sub_topic": "Section 8 voucher waitlists",
+    "description": "Long waits for housing vouchers",
+    "topic": "HOUSING",
+    "similarity_score": 0.91,
+}
+
+
+def make_candidate(
+    sub_topic: str = "lead pipe replacement funding",
+    description: str = "Funding gaps for replacing lead service lines.",
+    source_question: str = "When will the city replace the lead pipes in our neighborhood?",
+    doc_id: str = "doc-1",
+    retrieved_context: list[dict] | None = None,
+) -> ThemeCandidate:
+    return ThemeCandidate(
+        doc_id=doc_id,
+        source_question=source_question,
+        sub_topic=sub_topic,
+        description=description,
+        retrieved_context=retrieved_context or [],
+    )
+
+
+THRESHOLD = 0.4
+
+
+# ---------------------------------------------------------------------------
+# build_merge_split_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_merge_split_prompt_has_two_messages():
+    messages = build_merge_split_prompt(make_candidate())
+    assert len(messages) == 2
+
+
+def test_merge_split_prompt_system_first():
+    messages = build_merge_split_prompt(make_candidate())
+    assert messages[0]["role"] == "system"
+
+
+def test_merge_split_prompt_user_second():
+    messages = build_merge_split_prompt(make_candidate())
+    assert messages[1]["role"] == "user"
+
+
+def test_merge_split_prompt_system_explains_merge():
+    messages = build_merge_split_prompt(make_candidate())
+    assert "MERGE" in messages[0]["content"]
+    assert "NEW" in messages[0]["content"]
+
+
+def test_merge_split_prompt_system_lean_new():
+    """System prompt must instruct model to lean toward NEW when uncertain."""
+    messages = build_merge_split_prompt(make_candidate())
+    assert "lean toward NEW" in messages[0]["content"]
+
+
+def test_merge_split_prompt_user_contains_sub_topic():
+    candidate = make_candidate(sub_topic="water main breaks")
+    messages = build_merge_split_prompt(candidate)
+    assert "water main breaks" in messages[1]["content"]
+
+
+def test_merge_split_prompt_user_contains_description():
+    candidate = make_candidate(description="Frequent ruptures in aging water infrastructure.")
+    messages = build_merge_split_prompt(candidate)
+    assert "Frequent ruptures" in messages[1]["content"]
+
+
+def test_merge_split_prompt_user_contains_retrieved_themes():
+    candidate = make_candidate(retrieved_context=[HOUSING_SIMILAR])
+    messages = build_merge_split_prompt(candidate)
+    assert "Section 8 voucher waitlists" in messages[1]["content"]
+
+
+def test_merge_split_prompt_cold_start_message():
+    candidate = make_candidate(retrieved_context=[])
+    messages = build_merge_split_prompt(candidate)
+    assert "new theme" in messages[1]["content"].lower()
+
+
+# ---------------------------------------------------------------------------
+# build_question_type_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_qt_prompt_has_two_messages():
+    messages = build_question_type_prompt(make_candidate())
+    assert len(messages) == 2
+
+
+def test_qt_prompt_system_contains_all_question_types():
+    messages = build_question_type_prompt(make_candidate())
+    for qt in QuestionType:
+        assert qt.value in messages[0]["content"]
+
+
+def test_qt_prompt_system_contains_topic_taxonomy():
+    messages = build_question_type_prompt(make_candidate())
+    for topic in ["HOUSING", "EDUCATION", "TRANSPORTATION", "BUDGET"]:
+        assert topic in messages[0]["content"]
+
+
+def test_qt_prompt_system_mentions_low_confidence():
+    messages = build_question_type_prompt(make_candidate())
+    assert "low_confidence" in messages[0]["content"]
+
+
+def test_qt_prompt_system_mentions_proposed_new_type():
+    messages = build_question_type_prompt(make_candidate())
+    assert "proposed_new_type" in messages[0]["content"]
+
+
+def test_qt_prompt_user_contains_question():
+    q = "Why hasn't the city replaced the lead pipes yet?"
+    candidate = make_candidate(source_question=q)
+    messages = build_question_type_prompt(candidate)
+    assert q in messages[1]["content"]
+
+
+def test_qt_prompt_user_contains_sub_topic():
+    candidate = make_candidate(sub_topic="lead pipe replacement funding")
+    messages = build_question_type_prompt(candidate)
+    assert "lead pipe replacement funding" in messages[1]["content"]
+
+
+# ---------------------------------------------------------------------------
+# classify_one — merge/split decisions
+# ---------------------------------------------------------------------------
+
+
+def test_clear_new_case():
+    """No retrieved themes → decision=new, high confidence."""
+    merge_resp = _MergeSplitDecision(
+        decision="new", matched_theme=None, confidence=0.9, reasoning="Novel concern."
+    )
+    result = classify_one(
+        make_candidate(), FakeMergeLLM(merge_resp), FakeQTLLM(DEFAULT_QT_RESPONSE), THRESHOLD
+    )
+    assert result.decision == "new"
+    assert result.matched_theme is None
+    assert result.merge_confidence == 0.9
+
+
+def test_clear_merge_case():
+    """Candidate closely matches existing theme → decision=merge, matched_theme set."""
+    merge_resp = _MergeSplitDecision(
+        decision="merge",
+        matched_theme="Section 8 voucher waitlists",
+        confidence=0.88,
+        reasoning="Same underlying concern about housing voucher access.",
+    )
+    candidate = make_candidate(
+        sub_topic="housing voucher delays",
+        retrieved_context=[HOUSING_SIMILAR],
+    )
+    result = classify_one(
+        candidate, FakeMergeLLM(merge_resp), FakeQTLLM(DEFAULT_QT_RESPONSE), THRESHOLD
+    )
+    assert result.decision == "merge"
+    assert result.matched_theme == "Section 8 voucher waitlists"
+    assert result.merge_confidence == 0.88
+
+
+def test_borderline_case_flagged_for_review():
+    """Confidence below threshold → needs_review=True."""
+    merge_resp = _MergeSplitDecision(
+        decision="merge",
+        matched_theme="Section 8 voucher waitlists",
+        confidence=0.35,  # below 0.4 threshold
+        reasoning="Possible overlap but not certain.",
+    )
+    result = classify_one(
+        make_candidate(), FakeMergeLLM(merge_resp), FakeQTLLM(DEFAULT_QT_RESPONSE), THRESHOLD
+    )
+    assert result.needs_review is True
+
+
+def test_confident_case_not_flagged():
+    """Confidence at or above threshold → needs_review=False."""
+    merge_resp = _MergeSplitDecision(
+        decision="new", matched_theme=None, confidence=0.4, reasoning="Distinct."
+    )
+    result = classify_one(
+        make_candidate(), FakeMergeLLM(merge_resp), FakeQTLLM(DEFAULT_QT_RESPONSE), THRESHOLD
+    )
+    assert result.needs_review is False
+
+
+def test_threshold_boundary_exact():
+    """Confidence exactly at threshold is not flagged (threshold is exclusive lower bound)."""
+    merge_resp = _MergeSplitDecision(
+        decision="new", matched_theme=None, confidence=0.4, reasoning="At boundary."
+    )
+    result = classify_one(
+        make_candidate(), FakeMergeLLM(merge_resp), FakeQTLLM(DEFAULT_QT_RESPONSE), THRESHOLD
+    )
+    assert result.needs_review is False
+
+
+def test_merge_reasoning_preserved():
+    merge_resp = _MergeSplitDecision(
+        decision="new", matched_theme=None, confidence=0.9, reasoning="Unique issue."
+    )
+    result = classify_one(
+        make_candidate(), FakeMergeLLM(merge_resp), FakeQTLLM(DEFAULT_QT_RESPONSE), THRESHOLD
+    )
+    assert result.merge_reasoning == "Unique issue."
+
+
+# ---------------------------------------------------------------------------
+# classify_one — question type decisions
+# ---------------------------------------------------------------------------
+
+
+def test_question_type_assigned():
+    qt_resp = _QuestionTypeAndTopic(
+        question_type="accountability",
+        question_type_confidence=0.78,
+        low_confidence=False,
+        proposed_new_type=None,
+        topic="HOUSING",
+    )
+    result = classify_one(
+        make_candidate(), FakeMergeLLM(DEFAULT_MERGE_RESPONSE), FakeQTLLM(qt_resp), THRESHOLD
+    )
+    assert result.question_type == "accountability"
+    assert result.question_type_confidence == 0.78
+    assert result.question_type_low_confidence is False
+
+
+def test_question_type_low_confidence_flag_preserved():
+    """Low-confidence flag from model must be preserved in ClassifiedTheme."""
+    qt_resp = _QuestionTypeAndTopic(
+        question_type="skepticism",
+        question_type_confidence=0.45,
+        low_confidence=True,
+        proposed_new_type=None,
+        topic="PUBLIC SAFETY",
+    )
+    result = classify_one(
+        make_candidate(), FakeMergeLLM(DEFAULT_MERGE_RESPONSE), FakeQTLLM(qt_resp), THRESHOLD
+    )
+    assert result.question_type_low_confidence is True
+    assert result.question_type == "skepticism"  # still stored, just flagged
+
+
+def test_question_type_proposed_new_type_preserved():
+    """If model proposes a new type, it is stored in proposed_new_question_type."""
+    qt_resp = _QuestionTypeAndTopic(
+        question_type="uncertain",
+        question_type_confidence=0.30,
+        low_confidence=True,
+        proposed_new_type="anticipatory concern — reporter flags risk before it materializes",
+        topic="BUDGET",
+    )
+    result = classify_one(
+        make_candidate(), FakeMergeLLM(DEFAULT_MERGE_RESPONSE), FakeQTLLM(qt_resp), THRESHOLD
+    )
+    assert result.proposed_new_question_type is not None
+    assert "anticipatory" in result.proposed_new_question_type
+
+
+def test_question_type_uncertain_becomes_none():
+    """'uncertain' question_type is normalised to None in ClassifiedTheme."""
+    qt_resp = _QuestionTypeAndTopic(
+        question_type="uncertain",
+        question_type_confidence=0.20,
+        low_confidence=True,
+        proposed_new_type=None,
+        topic="HOUSING",
+    )
+    result = classify_one(
+        make_candidate(), FakeMergeLLM(DEFAULT_MERGE_RESPONSE), FakeQTLLM(qt_resp), THRESHOLD
+    )
+    assert result.question_type is None
+
+
+# ---------------------------------------------------------------------------
+# classify_one — topic assignment
+# ---------------------------------------------------------------------------
+
+
+def test_topic_assignment_preserved():
+    qt_resp = _QuestionTypeAndTopic(
+        question_type="knowledge_gap",
+        question_type_confidence=0.85,
+        low_confidence=False,
+        proposed_new_type=None,
+        topic="TRANSPORTATION",
+    )
+    result = classify_one(
+        make_candidate(), FakeMergeLLM(DEFAULT_MERGE_RESPONSE), FakeQTLLM(qt_resp), THRESHOLD
+    )
+    assert result.topic == "TRANSPORTATION"
+
+
+def test_topic_housing():
+    qt_resp = _QuestionTypeAndTopic(
+        question_type="knowledge_gap",
+        question_type_confidence=0.9,
+        low_confidence=False,
+        proposed_new_type=None,
+        topic="HOUSING",
+    )
+    result = classify_one(
+        make_candidate(), FakeMergeLLM(DEFAULT_MERGE_RESPONSE), FakeQTLLM(qt_resp), THRESHOLD
+    )
+    assert result.topic == "HOUSING"
+
+
+# ---------------------------------------------------------------------------
+# classify_one — input fields preserved
+# ---------------------------------------------------------------------------
+
+
+def test_doc_id_preserved():
+    result = classify_one(
+        make_candidate(doc_id="xyz-789"),
+        FakeMergeLLM(DEFAULT_MERGE_RESPONSE),
+        FakeQTLLM(DEFAULT_QT_RESPONSE),
+        THRESHOLD,
+    )
+    assert result.doc_id == "xyz-789"
+
+
+def test_source_question_preserved():
+    q = "Has the city applied for federal infrastructure funding?"
+    result = classify_one(
+        make_candidate(source_question=q),
+        FakeMergeLLM(DEFAULT_MERGE_RESPONSE),
+        FakeQTLLM(DEFAULT_QT_RESPONSE),
+        THRESHOLD,
+    )
+    assert result.source_question == q
+
+
+def test_retrieved_context_preserved():
+    result = classify_one(
+        make_candidate(retrieved_context=[HOUSING_SIMILAR]),
+        FakeMergeLLM(DEFAULT_MERGE_RESPONSE),
+        FakeQTLLM(DEFAULT_QT_RESPONSE),
+        THRESHOLD,
+    )
+    assert len(result.retrieved_context) == 1
+
+
+def test_result_is_classified_theme_instance():
+    result = classify_one(
+        make_candidate(),
+        FakeMergeLLM(DEFAULT_MERGE_RESPONSE),
+        FakeQTLLM(DEFAULT_QT_RESPONSE),
+        THRESHOLD,
+    )
+    assert isinstance(result, ClassifiedTheme)
+
+
+# ---------------------------------------------------------------------------
+# Hard cases — blurry taxonomy edges
+# ---------------------------------------------------------------------------
+
+SKEPTICISM_ACCOUNTABILITY_QUESTION = (
+    "The city said two years ago they'd replace these pipes — "
+    "why hasn't anything happened? Is this just another empty promise?"
+)
+
+
+def test_hard_case_skepticism_accountability_blur_low_confidence():
+    """A question blending skepticism and accountability should flag low_confidence."""
+    qt_resp = _QuestionTypeAndTopic(
+        question_type="accountability",
+        question_type_confidence=0.51,
+        low_confidence=True,   # model flags the blur
+        proposed_new_type=None,
+        topic="UTILITIES",
+    )
+    candidate = make_candidate(source_question=SKEPTICISM_ACCOUNTABILITY_QUESTION)
+    result = classify_one(
+        candidate, FakeMergeLLM(DEFAULT_MERGE_RESPONSE), FakeQTLLM(qt_resp), THRESHOLD
+    )
+    assert result.question_type_low_confidence is True
+    # A type is still assigned — model picks closest, doesn't refuse
+    assert result.question_type is not None
+
+
+def test_hard_case_no_fitting_label_proposes_new():
+    """If no existing label fits, model proposes a new type — that is preserved."""
+    qt_resp = _QuestionTypeAndTopic(
+        question_type="uncertain",
+        question_type_confidence=0.25,
+        low_confidence=True,
+        proposed_new_type="anticipatory concern — reporter flags a risk before it materializes",
+        topic="ENVIRONMENT",
+    )
+    candidate = make_candidate(
+        source_question="What happens if the dam fails during a major storm next year?"
+    )
+    result = classify_one(
+        candidate, FakeMergeLLM(DEFAULT_MERGE_RESPONSE), FakeQTLLM(qt_resp), THRESHOLD
+    )
+    assert result.proposed_new_question_type is not None
+    assert result.question_type is None  # "uncertain" → None
+
+
+# ---------------------------------------------------------------------------
+# run_classify_themes
+# ---------------------------------------------------------------------------
+
+
+def test_empty_candidates_returns_empty():
+    classified, needs_review = run_classify_themes(
+        [], FakeMergeLLM(DEFAULT_MERGE_RESPONSE), FakeQTLLM(DEFAULT_QT_RESPONSE), THRESHOLD
+    )
+    assert classified == []
+    assert needs_review == []
+
+
+def test_produces_one_classified_per_candidate():
+    candidates = [make_candidate(doc_id=f"d{i}") for i in range(3)]
+    classified, _ = run_classify_themes(
+        candidates,
+        FakeMergeLLM(DEFAULT_MERGE_RESPONSE),
+        FakeQTLLM(DEFAULT_QT_RESPONSE),
+        THRESHOLD,
+    )
+    assert len(classified) == 3
+
+
+def test_needs_review_subset_only_flagged():
+    """needs_review contains only items with needs_review=True."""
+    responses = [
+        _MergeSplitDecision(decision="new", matched_theme=None, confidence=0.9, reasoning=""),
+        _MergeSplitDecision(decision="merge", matched_theme="x", confidence=0.2, reasoning=""),
+        _MergeSplitDecision(decision="new", matched_theme=None, confidence=0.8, reasoning=""),
+    ]
+
+    class SequentialMergeLLM:
+        def __init__(self):
+            self._i = 0
+
+        def invoke(self, _):
+            r = responses[self._i]
+            self._i += 1
+            return r
+
+    candidates = [make_candidate(doc_id=f"d{i}") for i in range(3)]
+    classified, needs_review = run_classify_themes(
+        candidates, SequentialMergeLLM(), FakeQTLLM(DEFAULT_QT_RESPONSE), THRESHOLD
+    )
+    assert len(classified) == 3
+    assert len(needs_review) == 1
+    assert needs_review[0].merge_confidence == 0.2
+
+
+def test_needs_review_threshold_configurable():
+    """Raising the threshold flags more items for review."""
+    merge_resp = _MergeSplitDecision(
+        decision="new", matched_theme=None, confidence=0.55, reasoning=""
+    )
+    candidates = [make_candidate()]
+
+    _, needs_review_low = run_classify_themes(
+        candidates, FakeMergeLLM(merge_resp), FakeQTLLM(DEFAULT_QT_RESPONSE), review_threshold=0.4
+    )
+    _, needs_review_high = run_classify_themes(
+        candidates, FakeMergeLLM(merge_resp), FakeQTLLM(DEFAULT_QT_RESPONSE), review_threshold=0.6
+    )
+
+    assert len(needs_review_low) == 0   # 0.55 >= 0.4 → not flagged
+    assert len(needs_review_high) == 1  # 0.55 < 0.6 → flagged
+
+
+def test_llm_called_twice_per_candidate():
+    """Both merge LLM and QT LLM are called once per candidate."""
+    merge_llm = FakeMergeLLM(DEFAULT_MERGE_RESPONSE)
+    qt_llm = FakeQTLLM(DEFAULT_QT_RESPONSE)
+    candidates = [make_candidate(doc_id=f"d{i}") for i in range(2)]
+    run_classify_themes(candidates, merge_llm, qt_llm, THRESHOLD)
+    assert len(merge_llm.calls) == 2
+    assert len(qt_llm.calls) == 2


### PR DESCRIPTION
## Summary

- Adds `classify_themes.py` with `ClassifiedTheme`, two internal LLM schemas, and two prompt-construction functions
- Two calls per candidate: merge/split on `classify_model`, question-type + topic combined on `question_type_model`
- Merge prompt instructs model to lean NEW when uncertain (incorrect merges corrupt the library; incorrect splits surface to editors)
- `question_type="uncertain"` normalised to `None`; `proposed_new_question_type` carries the model's alternative when no label fits
- `needs_review=True` when `merge_confidence < review_confidence_threshold` (configurable, default 0.4)
- `GraphState.classified_themes` and `needs_review` narrowed from `list[Any]` to `list[ClassifiedTheme]`
- Lazy `ChatOpenAI` — cold-start graph runs need no `OPENAI_API_KEY`
- 39 new tests; 200 total passing, no warnings

## Test plan

- [x] `uv run pytest tests/test_classify_themes.py -v` — 39 tests pass
- [x] `uv run pytest` — all 200 tests pass, no warnings
- [ ] Review `_MERGE_SPLIT_SYSTEM` — does the MERGE/NEW framing and the "lean NEW" instruction feel right?
- [ ] Review `_QT_SYSTEM` — are the 5 category definitions clear enough to distinguish skepticism from accountability?
- [ ] Confirm `needs_review` threshold boundary: confidence exactly at 0.4 should NOT be flagged (`test_threshold_boundary_exact`)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)