### PR TITLE
feat: e2e fixture tests — 5 real Documenters notes (Issue #17)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,54 @@ Append-only log of work completed, decisions made, and things deferred. One entr
 
 ---
 
+## Issue #17 — End-to-end fixture tests
+
+**Date:** 2026-03-25
+
+**Branch:** `issue-17-e2e-fixture-tests`
+
+**What was built:**
+
+Five fixture files in `tests/fixtures/`, each derived from a real Signal Cleveland Documenters note. Each fixture was chosen to cover a specific hard case:
+
+- `fixture_no_questions.txt` — Urban Forestry Budget Committee (Jan 2026). No Follow-Up Questions section. Tests the graceful empty path: full graph runs without LLM calls.
+- `fixture_single_question.txt` — Cleveland City Council Health, Human Services and Arts Committee (Jan 2026). One question with skepticism/accountability ambiguity. Tests question type edge cases once integration tests are implemented.
+- `fixture_inline_editor_note.txt` — Cuyahoga County Council (Mar 2025). Editor's note inline in the first question (`[Editor's note: The City of Cleveland is one partner...]`). Tests that inline editorial annotations survive question parsing. The Browns stadium question also spans DEVELOPMENT + BUDGET + POLITICS topics.
+- `fixture_land_bank.txt` — Cuyahoga County Land Bank Board (Mar 2025). Three questions spanning governance, housing policy, and legal context. Notes section opens with a URL (`Agenda: https://...`), testing the extraction module's tolerance for URLs in the notes body.
+- `fixture_public_safety.txt` — Public Safety Technology Advisory Committee (Sep 2024). Three questions with accountability/continuity overlap. Tests question type classification edge cases once integration tests are implemented.
+
+`tests/conftest.py` — auto-skips integration tests when `OPENAI_API_KEY` is absent. Uses `pytest_collection_modifyitems` so the skip is applied at collection time without requiring the `@pytest.mark.skipif` boilerplate on every test.
+
+`pyproject.toml` — updated integration marker description to mention LLM APIs alongside Google APIs, since that is now the primary guard.
+
+`tests/test_e2e.py` — 12 CI tests (no LLM), 5 integration stubs (marked `# TK: integration`).
+
+CI tests cover:
+- Each fixture passes or fails the ingest gate as expected (all 5 pass).
+- Parsed question counts match the fixture content (0, 1, 3, 3, 3).
+- Inline editor's note survives question parsing intact.
+- Agency, ISO date, and meeting name extracted correctly from the Health fixture.
+- Full graph on the no-questions fixture completes without LLM calls.
+- Full graph on empty manifest completes without LLM calls.
+
+Integration stubs are skeleton tests with `pytest.skip("TK: integration — not yet implemented")`. They will be fleshed out after the first real run when OPENAI_API_KEY is available.
+
+**Key decisions:**
+
+- **Only the no-questions fixture can drive a full CI graph run.** With the current graph topology, any question in `retrieval_context` causes `_extract_candidates` to instantiate `ChatOpenAI`. The Urban Forestry fixture has no follow-up questions, so `retrieval_context` is empty and `extract_candidates` short-circuits before touching the OpenAI API. All other fixtures require real LLM calls to exercise beyond ingest.
+
+- **Fixture content includes editor's notes verbatim.** The inline `[Editor's note: ...]` in the County Council fixture is preserved in the question text by design — it provides real context for the LLM. The CI test asserts it survives; the integration test (stub) will verify the LLM handles it gracefully.
+
+- **Fixtures are trimmed but realistic.** Very long Notes sections were shortened to keep fixtures manageable, but the section structure, metadata, and full Follow-Up Questions sections are unmodified from the real Google Docs exports. The hard-case content (inline notes, cross-topic questions, URL in Notes) is preserved exactly as exported.
+
+**Deferred:**
+
+- Integration test bodies: stubs only. Will be implemented once we have an OPENAI_API_KEY in the test environment and have run the pipeline at least once.
+
+- The City Council HEAP Winter Crisis fixture (one very long question) was not included. It's a valid hard case (question longer than a sentence with nested sub-questions) but the five fixtures already cover the scope of this issue. Can be added when integration tests are implemented.
+
+---
+
 ## Issue #16 — Human review feedback: read decisions, update Theme Library
 
 **Date:** 2026-03-25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
 [tool.pytest.ini_options]
 env_files = [".env"]
 markers = [
-    "integration: tests that hit live Google APIs (require GOOGLE_APPLICATION_CREDENTIALS)",
+    "integration: tests that call live LLM or Google APIs (require OPENAI_API_KEY / GOOGLE_APPLICATION_CREDENTIALS)",
 ]
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""conftest.py — pytest configuration for documenters-cle-langchain tests.
+
+Auto-skips integration tests when OPENAI_API_KEY is absent so the full
+test suite runs cleanly in CI without any API credentials.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip integration tests when OPENAI_API_KEY is absent."""
+    if os.getenv("OPENAI_API_KEY"):
+        return
+    skip_marker = pytest.mark.skip(
+        reason="OPENAI_API_KEY not set — skipping integration tests"
+    )
+    for item in items:
+        if item.get_closest_marker("integration"):
+            item.add_marker(skip_marker)

--- a/tests/fixtures/fixture_inline_editor_note.txt
+++ b/tests/fixtures/fixture_inline_editor_note.txt
@@ -1,0 +1,31 @@
+Council Meeting
+Documenter name: Andrew Kenneson
+Agency: Cuyahoga County Council
+Date: March 25, 2025
+See more about this meeting at Documenters.org
+
+Summary
+* Cuyahoga County Council awarded a $300,000 community development grant for the African Town Plaza project, which will renovate the former YMCA building at 7515 Cedar Ave. into a business hub, event space and apartments.
+* Council approved converting a $200,000 affordable housing loan to Lutheran Metropolitan Ministry to a grant for the construction of four homes for people experiencing homelessness in Cleveland.
+* Council approved directing roughly $80 million of federal money to the City of Painesville to help construct a 35 megawatt solar and storage facility on the site of an old coal plant.
+
+Follow-Up Questions
+* Who else is funding the African Town development? [Editor's note: The City of Cleveland is one partner set to support the project.]
+* Who would pay for the demolition of the Browns stadium should they move to Brook Park?
+* Will Painesville be able to complete the solar project, given that the federal government is now not as supportive of renewable energy?
+
+Notes
+Public Comment
+
+Darrell Houston, of Bedford Heights, said he was concerned about the process of how Cuyahoga County adjusted property taxes. He said his taxes doubled and he thinks they should have stayed the same.
+
+Dale Snyder (spelling unconfirmed), of Cuyahoga County, said he had questions about the $80 million solar energy in Lake County because he knew people who could benefit from job training in this field.
+
+Notable Legislation
+
+Council approved a $300,000 community development grant for African Town Plaza. This project will renovate the old YMCA building at 7515 Cedar Road into a business hub, event space and apartments. Council President Dale Miller added that the county will also loan the development an additional $450,000.
+
+In July 2024, the EPA announced around $129 million for renewable energy in the Cleveland area. Part of that is $80 million for a solar project in Painesville. That money first had to pass through Cuyahoga County.
+
+Single Signal
+* I'd like to know more about the African Town Plaza development. It seems like a fun story and could be a real asset to the neighborhood.

--- a/tests/fixtures/fixture_land_bank.txt
+++ b/tests/fixtures/fixture_land_bank.txt
@@ -1,0 +1,34 @@
+Board of Directors (in-person only)
+Documenter name: Maria Zajac
+Agency: Cuyahoga County Land Bank
+Date: March 28, 2025
+See more about this meeting at Documenters.org
+
+Summary
+* The board elected County Treasurer Brad Cromes to board chair and Anthony Brancatelli as vice chair. This followed an executive session to discuss Cromes' possible conflicts of interest.
+* They went over reports on projects, the Cuyahoga Housing Program (CHP), finances, contractors, production, legislation, litigation and demolition.
+* They passed a resolution implementing a hybrid work policy, which land bank CEO Ricardo León said would make it easier to hire talent.
+
+Follow-Up Questions
+   * How was the dispute over who chaired the board resolved?
+   * Does the land bank track what happens to housing and their residents once it's built?
+   * What is going on with lawsuits against land banks? Chair Cromes wondered if there are other lawsuits against land banks like the one against him. Why was he sued and why would this be an issue for other land banks?
+
+Notes
+Agenda: https://cuyahogalandbank.org/wp-content/uploads/2025/03/20250328_agenda_cclrc_board.pdf
+
+The Cuyahoga County Land Bank is a private, non-profit entity that was established in 2009 by the State of Ohio. The Land Bank acquires vacant and blighted properties and restores them to productivity through renovation, sales, construction or demolition.
+
+The meeting was called to order at 10 a.m. by Interim Chair Brad Cromes, Cuyahoga County Treasurer.
+
+Nomination and election of chair and vice chair:
+Interim Chair Brad Cromes said he wanted to serve as chair. He cited his previous chairmanship of a land bank in Portage County. Some members were concerned about conflicts of interest because Cromes is the county treasurer.
+
+Blackwell motioned to move to executive session for further discussion. After the session, Cromes was the only nominee and was elected chair by voice vote. Brancatelli was elected vice chair 5-3 over Blackwell.
+
+Litigation:
+The Land Bank was in a lease dispute with a tenant in the Mickey Building in East Cleveland. The parties reached a settlement.
+Craig v. Cromes was dismissed on failure to state a claim. Cromes wondered if there are other counties in Ohio with similar lawsuits. [Editor's note: The suit was related to tax foreclosures and direct transfers, according to minutes from a September 2024 meeting.]
+
+Single Signal
+* ...

--- a/tests/fixtures/fixture_no_questions.txt
+++ b/tests/fixtures/fixture_no_questions.txt
@@ -1,0 +1,39 @@
+Budget Committee
+Documenter name: Alfreda Williams
+Agency: City of Cleveland Urban Forestry Commission
+Date: Jan. 9, 2026
+See more about this meeting at Documenters.org
+
+Summary
+* This meeting was a little hard to follow and was shorter than anticipated.
+* The questions asked didn't seem to generate substantive answers.
+
+Notes
+Meeting start time: noon.
+
+Quorum met with the following members present:
+* Xavier Bay, commission secretary (City Planning, Cleveland) and WebEx host
+* Jinan Berard (commission's youth resident representative)
+* Jennifer Chandler, full commission chair (CHN Housing Partners)
+* Sarah Tillie, committee chair (Cleveland Tree Coalition)
+
+Agenda [Editor's note: The city provided only an image of the agenda. The Documenter typed the titles of the sections and filled in additional detail for each section.]
+
+I. Welcome and introductions
+The meeting was opened by Bay.
+
+II. Review and update committee charter
+The committee charter was updated. All members present requested to remain as committee members.
+
+III. Old business
+Tillie recapped committee activities in 2025, highlighting a memo sent to Cleveland Director of Parks and Recreation Alexandria Nichols that detailed how other governments' urban forestry units work.
+
+IV. New business
+The 2026 operational budget presentation is set for February. Committee members discussed leveraging the capital budget. Tille spoke about the Tree Preservation Fund, which has about $19,000.
+
+V. Wrap-up
+Bay said the committee should approve the last meeting's minutes at the next meeting.
+Meeting ended: 12:40 p.m.
+
+Single Signal
+* ...

--- a/tests/fixtures/fixture_public_safety.txt
+++ b/tests/fixtures/fixture_public_safety.txt
@@ -1,0 +1,25 @@
+Public Safety Technology Advisory Committee [in-person only]
+Documenter name: Stesia Swain
+Agency: Public Safety Technology Advisory Committee
+Date: Sept. 17, 2024
+See more about this meeting at Documenters.org
+
+Summary
+* The concerns of the community regarding the use of police surveillance technologies were voiced and solutions were promised.
+* The delay in establishing police technology oversight was addressed with a vow to not delay transparency any further.
+* Community concerns about technology being used to discriminate against the public were also addressed.
+
+Follow-Up Questions
+   * Although dates are being discussed as far as when all that is promised will be set in stone, I'm left wondering if these things are actually going to happen. Is there really a for-certain "When" for oversight and transparency?
+   * Since Mayor Justin Bibb's 2022 pledge for more oversight and transparency regarding these technologies, certain meetings have been held about these issues. I'm curious as to why these issues are only being addressed in a public meeting with commissioners and important teams two years later.
+   * How can we encourage more accountability for officials?
+
+Notes
+In 2022, Bibb pledged to form a panel to address concerns about cameras and other high-tech tools used by police. It was in part a response to community concerns about the lack of oversight and/or supervision of the police officers using these tools. Some residents feel that these tools put them under a dangerous spotlight and worry that their movements may be tracked by police.
+
+During this meeting, the concerns of residents were very briefly mentioned. According to reporting from The Marshall Project - Cleveland, these concerns include that police may use the images from cameras to identify potential targets and suspects using facial recognition, which may lead to discriminatory policing of residents, particularly people of color.
+
+Bibb briefly mentioned the delay in establishing this oversight committee. He said that their efforts to ensure that residents are comfortable with technology such as plate readers, cameras, and dashboard cameras is well underway. The Cleveland Community Police Commission is also tasked with oversight over police technology policies.
+
+Single Signal
+* I truly feel that this meeting only addressed surface issues. I think that we as a community should be vocal about the lack of urgency that is being exuded on this issue.

--- a/tests/fixtures/fixture_single_question.txt
+++ b/tests/fixtures/fixture_single_question.txt
@@ -1,0 +1,24 @@
+Health, Human Services and the Arts Committee
+Documenter name: Bilal Hakeem
+Agency: Cleveland City Council
+Date: Jan. 12, 2026
+See more about this meeting at Documenters.org
+
+Summary
+* The Music Settlement is working on an expansion of its University Circle campus.
+* Council members and officials discussed health department programs.
+
+Follow-Up Questions
+   * Ward 1 Council Member Joe Jones spoke about dire health outcomes in the Lee-Harvard area. How can that be the case with a neighborhood that neighbors the suburbs of Shaker Heights and Warrensville Heights and is near Cleveland Clinic South Pointe Hospital?
+
+Notes
+Cleveland City Council Health, Human Services, and the Arts Committee meeting. Jan. 12 9:30 a.m.
+
+The committee's chair, Council Member Kevin Conwell, Vice Chair Austin Davis and the five other committee members were present. The arts community was represented by officials from The Music Settlement, which offers music programming to newcomers to Cleveland and the community at large.
+
+Lita Wills, commissioner of the health department's Health, Equity, and Social Justice Division, made it clear that racism is a public health crisis, as Cleveland City Council declared in 2020. She provided a cascade of information on various health outcomes that was difficult to ignore.
+
+Ward 1 Council Member Joe Jones called out his ward's ZIP code, 44128, and said the administration wasn't communicating statistics on infant mortality rates or how medical outcomes for Black women have changed in the area. He said his neighborhood has "Third World situations" as far as quality of life.
+
+Single Signal
+* ...How is all this information improving residents daily lives?

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,287 @@
+"""test_e2e.py — end-to-end fixture tests.
+
+Smoke-tests the full pipeline against real Documenters notes captured as
+text fixtures. The fixture files are checked into the repo so all CI tests
+here run without any credentials.
+
+CI tests (no LLM):
+  - Every fixture passes the ingest gate.
+  - Parsed question counts match the fixture content.
+  - Known hard cases survive ingest intact (inline editor notes, long
+    questions, formatting quirks).
+  - The full graph completes on the "no questions" fixture — cold-start,
+    no LLM calls required.
+
+Integration tests (require OPENAI_API_KEY):
+  - Each fixture runs through the full graph with a real LLM.
+  - Results are smoke-tested for structural validity.
+  - Stubs marked # TK: integration — not yet implemented.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from documenters_cle_langchain.graph import GraphState, build_graph
+from documenters_cle_langchain.ingest import run_ingest
+
+# ---------------------------------------------------------------------------
+# Fixture loading helpers
+# ---------------------------------------------------------------------------
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def _load_fixture(filename: str) -> str:
+    return (FIXTURES_DIR / filename).read_text(encoding="utf-8")
+
+
+def _make_manifest_doc(doc_id: str, name: str, text: str) -> dict:
+    return {
+        "doc_id": doc_id,
+        "name": name,
+        "web_url": f"https://example.com/{doc_id}",
+        "folder_path": "",
+        "modified_time": "",
+        "text": text,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Ingest — gate and question counts
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_no_questions_passes_gate():
+    """Urban Forestry: no Follow-Up Questions section → passes gate, 0 questions."""
+    text = _load_fixture("fixture_no_questions.txt")
+    doc = _make_manifest_doc("doc_urban_forestry", "Urban Forestry Budget Committee", text)
+    ingested, skipped = run_ingest([doc])
+    assert skipped == [], f"Unexpected gate failure: {skipped}"
+    assert len(ingested) == 1
+    assert ingested[0]["follow_up_questions"] == []
+
+
+def test_ingest_single_question_passes_gate():
+    """Health Committee: one indignant question → passes gate, 1 question."""
+    text = _load_fixture("fixture_single_question.txt")
+    doc = _make_manifest_doc("doc_health", "Health Committee", text)
+    ingested, skipped = run_ingest([doc])
+    assert skipped == []
+    assert len(ingested) == 1
+    assert len(ingested[0]["follow_up_questions"]) == 1
+
+
+def test_ingest_inline_editor_note_passes_gate():
+    """County Council: editor's note inline in first question → passes gate, 3 questions."""
+    text = _load_fixture("fixture_inline_editor_note.txt")
+    doc = _make_manifest_doc("doc_county_council", "Cuyahoga County Council", text)
+    ingested, skipped = run_ingest([doc])
+    assert skipped == []
+    assert len(ingested) == 1
+    assert len(ingested[0]["follow_up_questions"]) == 3
+
+
+def test_ingest_inline_editor_note_survives_in_question():
+    """Editor's note content is preserved as part of the question text."""
+    text = _load_fixture("fixture_inline_editor_note.txt")
+    doc = _make_manifest_doc("doc_county_council", "Cuyahoga County Council", text)
+    ingested, _ = run_ingest([doc])
+    first_q = ingested[0]["follow_up_questions"][0]
+    # The editor's note is inline — it should survive question parsing
+    assert "African Town" in first_q
+    assert "Editor's note" in first_q
+
+
+def test_ingest_land_bank_passes_gate():
+    """Land Bank: 3 questions spanning governance/legal/housing → passes gate."""
+    text = _load_fixture("fixture_land_bank.txt")
+    doc = _make_manifest_doc("doc_land_bank", "Cuyahoga County Land Bank Board", text)
+    ingested, skipped = run_ingest([doc])
+    assert skipped == []
+    assert len(ingested) == 1
+    assert len(ingested[0]["follow_up_questions"]) == 3
+
+
+def test_ingest_public_safety_passes_gate():
+    """Public Safety Tech: 3 questions with accountability/continuity overlap → passes gate."""
+    text = _load_fixture("fixture_public_safety.txt")
+    doc = _make_manifest_doc("doc_public_safety", "Public Safety Technology Advisory Committee", text)
+    ingested, skipped = run_ingest([doc])
+    assert skipped == []
+    assert len(ingested) == 1
+    assert len(ingested[0]["follow_up_questions"]) == 3
+
+
+def test_ingest_metadata_extracted_correctly():
+    """Spot-check: agency, ISO date, and meeting name from the Health fixture."""
+    text = _load_fixture("fixture_single_question.txt")
+    doc = _make_manifest_doc("doc_health", "Health Committee", text)
+    ingested, _ = run_ingest([doc])
+    record = ingested[0]
+    assert "Cleveland City Council" in record["agency"]
+    assert record["date"] == "2026-01-12"
+    assert "Health" in record["meeting_name"]
+
+
+def test_ingest_batch_all_pass_gate():
+    """All five fixtures pass the gate when ingested together."""
+    manifest = [
+        _make_manifest_doc("f1", "Urban Forestry", _load_fixture("fixture_no_questions.txt")),
+        _make_manifest_doc("f2", "Health Committee", _load_fixture("fixture_single_question.txt")),
+        _make_manifest_doc("f3", "County Council", _load_fixture("fixture_inline_editor_note.txt")),
+        _make_manifest_doc("f4", "Land Bank", _load_fixture("fixture_land_bank.txt")),
+        _make_manifest_doc("f5", "Public Safety", _load_fixture("fixture_public_safety.txt")),
+    ]
+    ingested, skipped = run_ingest(manifest)
+    assert skipped == [], f"Unexpected gate failures: {[s['doc_id'] for s in skipped]}"
+    assert len(ingested) == 5
+
+
+def test_ingest_question_counts_batch():
+    """Correct question counts across all five fixtures."""
+    manifest = [
+        _make_manifest_doc("f1", "Urban Forestry", _load_fixture("fixture_no_questions.txt")),
+        _make_manifest_doc("f2", "Health Committee", _load_fixture("fixture_single_question.txt")),
+        _make_manifest_doc("f3", "County Council", _load_fixture("fixture_inline_editor_note.txt")),
+        _make_manifest_doc("f4", "Land Bank", _load_fixture("fixture_land_bank.txt")),
+        _make_manifest_doc("f5", "Public Safety", _load_fixture("fixture_public_safety.txt")),
+    ]
+    ingested, _ = run_ingest(manifest)
+    q_counts = {doc["doc_id"]: len(doc["follow_up_questions"]) for doc in ingested}
+    assert q_counts["f1"] == 0, "Urban Forestry: no questions"
+    assert q_counts["f2"] == 1, "Health Committee: one question"
+    assert q_counts["f3"] == 3, "County Council: three questions"
+    assert q_counts["f4"] == 3, "Land Bank: three questions"
+    assert q_counts["f5"] == 3, "Public Safety: three questions"
+
+
+# ---------------------------------------------------------------------------
+# Full graph — cold-start, no LLM calls
+# ---------------------------------------------------------------------------
+
+_MINIMAL_STATE: GraphState = {
+    "manifest_docs": [],
+    "sheet_id": None,
+    "run_date": "2026-03-25",
+    "theme_library": [],
+    "prior_decisions": [],
+    "ingested_docs": [],
+    "skipped_docs": [],
+    "retrieval_context": [],
+    "candidates": [],
+    "classified_themes": [],
+    "needs_review": [],
+    "run_summary": {},
+}
+
+
+def test_graph_no_questions_no_llm_calls():
+    """Full graph on the no-questions fixture: cold-start, no LLM instantiated.
+
+    Urban Forestry has no Follow-Up Questions section → retrieval_context is
+    empty → extract_candidates short-circuits before touching ChatOpenAI.
+    """
+    text = _load_fixture("fixture_no_questions.txt")
+    state = {
+        **_MINIMAL_STATE,
+        "manifest_docs": [
+            _make_manifest_doc("doc_urban_forestry", "Urban Forestry Budget Committee", text)
+        ],
+    }
+    result = build_graph().invoke(state)
+
+    assert len(result["ingested_docs"]) == 1
+    assert result["ingested_docs"][0]["follow_up_questions"] == []
+    assert result["retrieval_context"] == []
+    assert result["candidates"] == []
+    assert result["classified_themes"] == []
+    assert result["run_summary"] == {"sheets_written": 0}
+
+
+def test_graph_empty_manifest_no_llm():
+    """Full graph with no docs: nothing to ingest or classify."""
+    result = build_graph().invoke({**_MINIMAL_STATE, "manifest_docs": []})
+    assert result["ingested_docs"] == []
+    assert result["classified_themes"] == []
+    assert result["run_summary"] == {"sheets_written": 0}
+
+
+def test_graph_all_no_questions_batch_no_llm():
+    """All five fixtures in one batch: Urban Forestry drives cold-start path.
+
+    The other four fixtures have questions, so retrieval_context is non-empty
+    and extract_candidates would fire — but all four are gated behind
+    OPENAI_API_KEY. This test runs only the no-questions fixture.
+    """
+    text = _load_fixture("fixture_no_questions.txt")
+    state = {
+        **_MINIMAL_STATE,
+        "manifest_docs": [
+            _make_manifest_doc("doc_urban_forestry", "Urban Forestry Budget Committee", text)
+        ],
+    }
+    result = build_graph().invoke(state)
+    assert result["skipped_docs"] == []
+    assert result["classified_themes"] == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — require OPENAI_API_KEY
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_integration_single_question_health_committee():
+    """Full graph against Health Committee fixture with real LLM.
+
+    Single question is skeptical/accountability-ambiguous. Expect exactly
+    one ClassifiedTheme with a non-empty sub_topic.
+    """
+    # TK: integration
+    pytest.skip("TK: integration — not yet implemented")
+
+
+@pytest.mark.integration
+def test_integration_inline_editor_note_county_council():
+    """Full graph against County Council fixture with real LLM.
+
+    Editor's note is inline in the first question. The LLM should handle
+    it gracefully and return 3 classified themes. The Browns stadium question
+    may span DEVELOPMENT + BUDGET topics — verify no crash, non-empty sub_topics.
+    """
+    # TK: integration
+    pytest.skip("TK: integration — not yet implemented")
+
+
+@pytest.mark.integration
+def test_integration_land_bank():
+    """Full graph against Land Bank fixture with real LLM.
+
+    Third question spans governance/legal. Verify 3 classified themes, no crash.
+    """
+    # TK: integration
+    pytest.skip("TK: integration — not yet implemented")
+
+
+@pytest.mark.integration
+def test_integration_public_safety():
+    """Full graph against Public Safety fixture with real LLM.
+
+    Questions 1-2 have accountability/continuity ambiguity. Verify 3 themes,
+    non-empty question types.
+    """
+    # TK: integration
+    pytest.skip("TK: integration — not yet implemented")
+
+
+@pytest.mark.integration
+def test_integration_all_fixtures_batch():
+    """Full graph against all five fixtures in one batch with real LLM.
+
+    Smoke test: all fixture docs should either produce ClassifiedThemes or
+    land in skipped_docs — no unhandled exceptions.
+    """
+    # TK: integration
+    pytest.skip("TK: integration — not yet implemented")


### PR DESCRIPTION
## Summary

- Five fixture files from real Signal Cleveland Documenters notes, each targeting a specific hard case
- 12 CI tests (no LLM calls needed) covering ingest gate, question counts, inline editor note preservation, full graph cold-start
- 5 integration test stubs (`# TK: integration`) that auto-skip when `OPENAI_API_KEY` is absent
- `tests/conftest.py` auto-skips integration tests at collection time
- Updated `pyproject.toml` integration marker to mention LLM APIs

## Fixtures

| File | Meeting | Hard case |
|------|---------|-----------|
| `fixture_no_questions.txt` | Urban Forestry Budget Committee | No Follow-Up Questions → full graph without LLM |
| `fixture_single_question.txt` | Health, Human Services and Arts Committee | Single question, skepticism/accountability ambiguity |
| `fixture_inline_editor_note.txt` | Cuyahoga County Council | `[Editor's note: ...]` inline in question 1; Browns stadium cross-topic |
| `fixture_land_bank.txt` | Cuyahoga County Land Bank Board | 3 questions; URL in Notes; governance/legal/housing cross-topic |
| `fixture_public_safety.txt` | Public Safety Technology Advisory Committee | 3 questions; accountability/continuity ambiguity |

## Test plan

- [x] `uv run pytest` — 276 passed, 5 skipped (integration stubs)
- [x] All five fixtures pass the ingest gate
- [x] Question counts match fixture content (0, 1, 3, 3, 3)
- [x] Inline editor's note survives question parsing
- [x] Full graph on no-questions fixture completes without OPENAI_API_KEY

🤖 Generated with [Claude Code](https://claude.com/claude-code)