### PR TITLE
feat: support multiple sub-topics per question

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,36 @@ Append-only log of work completed, decisions made, and things deferred. One entr
 
 ---
 
+## Issue #44 — Support multiple sub-topics (and output rows) per question
+
+**Date:** 2026-03-26
+
+**Branch:** `issue-44-multiple-subtopics`
+
+**What was built:**
+
+Changed `extract_candidates.py` from a one-to-one (question → candidate) model to one-to-many (question → 1+ candidates).
+
+- New internal schema: `_SingleTheme(sub_topic, description)` and `_ExtractedTheme(themes: list[_SingleTheme])`. One LLM call per question; the model returns a list of sub-topic/description pairs.
+- `run_extract_candidates` now flattens: each `_SingleTheme` in the response produces one `ThemeCandidate`. Shared fields (`doc_id`, `source_question`, `retrieved_context`) are stamped on all candidates from the same question.
+- Prompts updated: "propose one or more sub-topic labels" with an explicit note that most questions map to exactly one — only split when the question genuinely addresses distinct civic issues.
+
+Tests: replaced the one-to-one hard-case test with three new tests proving that a two-theme response from a single LLM call produces two candidates sharing `source_question`, `doc_id`, and `retrieved_context`. `test_at_least_one_candidate_per_question` (≥ N) replaces the old exact-count test. 31 tests in the file; 294 total pass.
+
+**Key decisions:**
+
+- **One LLM call per question, not one call per candidate.** Splitting into multiple calls would be wasteful and inconsistent — the model has all the context it needs for a single question in one prompt. The list structure in the response schema handles the multi-topic case naturally.
+
+- **Prompts discourage over-splitting.** "Most questions have exactly one sub-topic" is stated explicitly in both the system and user messages. Without this guardrail, the model might split anything remotely compound.
+
+- **No downstream changes needed.** `classify_themes` consumes a `list[ThemeCandidate]` with no assumption about how many candidates came from the same question. The write-back step writes one row per `ClassifiedTheme`, so multi-topic questions already produce multiple rows naturally.
+
+**Deferred:**
+
+- Sub-topic prompt specificity: user noted prompts are "way too specific" but wants to see RAG results from a real run before adjusting. No prompt changes made beyond the one-to-many framing.
+
+---
+
 ## Issue #23 — text_extract.py: preserve hyperlink URLs from Google Docs
 
 **Date:** 2026-03-26

--- a/src/documenters_cle_langchain/extract_candidates.py
+++ b/src/documenters_cle_langchain/extract_candidates.py
@@ -1,12 +1,11 @@
 """extract_candidates.py — LLM-based theme candidate extraction.
 
-For each follow-up question, produces a ThemeCandidate: proposed sub-topic
-label, description, source question verbatim, and the retrieval context that
-was provided to the model.
+For each follow-up question, produces one or more ThemeCandidates: proposed
+sub-topic label(s), description(s), source question verbatim, and the retrieval
+context that was provided to the model.
 
-One question → one candidate. This is a deliberate starting constraint.
-Genuinely multi-theme questions exist in practice; revisit with LangSmith
-evidence after the first real run before relaxing the one-to-one rule.
+Most questions map to exactly one sub-topic. The LLM may return multiple only
+when a question genuinely and distinctly addresses separate civic issues.
 
 Called by the `extract_candidates` node in graph.py.
 """
@@ -41,11 +40,15 @@ class ThemeCandidate(BaseModel):
     retrieved_context: list[dict]  # SimilarTheme dicts shown to the model as context
 
 
-# Internal LLM output schema — only the two fields the model generates.
+# Internal LLM output schema — one or more sub-topic/description pairs.
 # We add doc_id, source_question, and retrieved_context from the input data.
-class _ExtractedTheme(BaseModel):
+class _SingleTheme(BaseModel):
     sub_topic: str
     description: str
+
+
+class _ExtractedTheme(BaseModel):
+    themes: list[_SingleTheme]
 
 
 # ---------------------------------------------------------------------------
@@ -63,10 +66,12 @@ to track over time across multiple meetings. Examples:
   - "Lead pipe replacement funding" (not "infrastructure")
   - "Police union contract negotiations" (not "public safety")
 
-Your job: given a follow-up question from a community reporter, propose a \
-single sub-topic label and a 1-2 sentence description of the underlying civic \
-concern. The label should be specific, lowercase, and suitable as a canonical \
-theme name that could recur across meetings."""
+Your job: given a follow-up question from a community reporter, propose one or \
+more sub-topic labels and 1-2 sentence descriptions of the underlying civic \
+concerns. Most questions map to exactly one sub-topic — only propose multiple \
+if the question genuinely and distinctly addresses separate civic issues. \
+Labels should be specific, lowercase, and suitable as canonical theme names \
+that could recur across meetings."""
 
 USER_PROMPT = """\
 Follow-up question from reporter:
@@ -74,9 +79,10 @@ Follow-up question from reporter:
 
 {context_section}
 
-Propose a single sub-topic label and a 1-2 sentence description for the civic \
-concern expressed in this question. If the question touches multiple issues, \
-choose the most specific and actionable one."""
+Propose sub-topic label(s) and description(s) for the civic concern(s) \
+expressed in this question. Most questions have exactly one sub-topic. \
+Only propose multiple if the question clearly addresses distinct civic issues \
+that would be tracked separately."""
 
 
 def _format_similar_themes(similar_themes: list[SimilarTheme]) -> str:
@@ -131,12 +137,12 @@ def run_extract_candidates(
     retrieval_context: list[QuestionContext],
     llm: Any,  # ChatOpenAI.with_structured_output(_ExtractedTheme), or a test fake
 ) -> list[ThemeCandidate]:
-    """Extract one ThemeCandidate per follow-up question.
+    """Extract one or more ThemeCandidates per follow-up question.
 
-    One-to-one: each QuestionContext produces exactly one ThemeCandidate.
-    The LLM receives the question text and retrieved similar themes; it returns
-    a sub-topic label and description. Metadata (doc_id, source_question,
-    retrieved_context) is attached by this function, not by the LLM.
+    One LLM call per question. The LLM returns a list of sub-topic/description
+    pairs (usually one, occasionally more for genuinely multi-issue questions).
+    Each pair produces one ThemeCandidate with the same source question and
+    retrieved context.
 
     Args:
         retrieval_context: one QuestionContext per question (from retrieve_context node).
@@ -145,26 +151,27 @@ def run_extract_candidates(
              interface.
 
     Returns:
-        One ThemeCandidate per entry in retrieval_context, in the same order.
+        One or more ThemeCandidates per entry in retrieval_context.
     """
     candidates: list[ThemeCandidate] = []
 
     for ctx in retrieval_context:
         messages = build_extraction_prompt(ctx["question"], ctx["similar_themes"])
         extracted: _ExtractedTheme = llm.invoke(messages)
-        candidate = ThemeCandidate(
-            doc_id=ctx["doc_id"],
-            source_question=ctx["question"],
-            sub_topic=extracted.sub_topic,
-            description=extracted.description,
-            retrieved_context=list(ctx["similar_themes"]),
-        )
-        candidates.append(candidate)
-        log.info(
-            "extract_candidates: '%s…' → sub_topic='%s'",
-            ctx["question"][:60],
-            extracted.sub_topic,
-        )
+        for theme in extracted.themes:
+            candidate = ThemeCandidate(
+                doc_id=ctx["doc_id"],
+                source_question=ctx["question"],
+                sub_topic=theme.sub_topic,
+                description=theme.description,
+                retrieved_context=list(ctx["similar_themes"]),
+            )
+            candidates.append(candidate)
+            log.info(
+                "extract_candidates: '%s…' → sub_topic='%s'",
+                ctx["question"][:60],
+                theme.sub_topic,
+            )
 
     log.info(
         "extract_candidates: %d questions → %d candidates",

--- a/tests/test_extract_candidates.py
+++ b/tests/test_extract_candidates.py
@@ -10,6 +10,7 @@ import pytest
 from documenters_cle_langchain.extract_candidates import (
     ThemeCandidate,
     _ExtractedTheme,
+    _SingleTheme,
     _format_similar_themes,
     build_extraction_prompt,
     run_extract_candidates,
@@ -72,10 +73,12 @@ EDUCATION_THEME = make_similar_theme(
     "EDUCATION",
 )
 
-DEFAULT_RESPONSE = _ExtractedTheme(
-    sub_topic="Section 8 voucher waitlists",
-    description="Community members face long waits for housing vouchers.",
-)
+DEFAULT_RESPONSE = _ExtractedTheme(themes=[
+    _SingleTheme(
+        sub_topic="Section 8 voucher waitlists",
+        description="Community members face long waits for housing vouchers.",
+    )
+])
 
 # ---------------------------------------------------------------------------
 # _format_similar_themes
@@ -189,11 +192,11 @@ def test_empty_retrieval_context_returns_empty_candidates():
 
 
 # ---------------------------------------------------------------------------
-# run_extract_candidates — one-to-one contract
+# run_extract_candidates — one LLM call per question
 # ---------------------------------------------------------------------------
 
 
-def test_one_candidate_per_question():
+def test_at_least_one_candidate_per_question():
     contexts = [
         make_context("doc1", "Question one?"),
         make_context("doc1", "Question two?"),
@@ -201,7 +204,7 @@ def test_one_candidate_per_question():
     ]
     llm = FakeLLM(DEFAULT_RESPONSE)
     candidates = run_extract_candidates(contexts, llm)
-    assert len(candidates) == 3
+    assert len(candidates) >= 3
 
 
 def test_llm_called_once_per_question():
@@ -216,8 +219,8 @@ def test_llm_called_once_per_question():
 
 def test_candidate_order_matches_context_order():
     responses = [
-        _ExtractedTheme(sub_topic="first theme", description="first"),
-        _ExtractedTheme(sub_topic="second theme", description="second"),
+        _ExtractedTheme(themes=[_SingleTheme(sub_topic="first theme", description="first")]),
+        _ExtractedTheme(themes=[_SingleTheme(sub_topic="second theme", description="second")]),
     ]
 
     class SequentialFakeLLM:
@@ -257,14 +260,14 @@ def test_candidate_source_question_preserved():
 
 
 def test_candidate_sub_topic_from_llm():
-    response = _ExtractedTheme(sub_topic="lead pipe replacement", description="desc")
+    response = _ExtractedTheme(themes=[_SingleTheme(sub_topic="lead pipe replacement", description="desc")])
     ctx = make_context("doc1", "Question?")
     candidates = run_extract_candidates([ctx], FakeLLM(response))
     assert candidates[0].sub_topic == "lead pipe replacement"
 
 
 def test_candidate_description_from_llm():
-    response = _ExtractedTheme(sub_topic="label", description="Custom description text.")
+    response = _ExtractedTheme(themes=[_SingleTheme(sub_topic="label", description="Custom description text.")])
     ctx = make_context("doc1", "Question?")
     candidates = run_extract_candidates([ctx], FakeLLM(response))
     assert candidates[0].description == "Custom description text."
@@ -299,26 +302,56 @@ AMBIGUOUS_QUESTION = (
 )
 
 
-def test_hard_case_ambiguous_question_produces_single_candidate():
-    """A question spanning housing and education must produce exactly one candidate.
+def test_hard_case_ambiguous_question_can_produce_multiple_candidates():
+    """A question spanning housing and education may produce two candidates.
 
-    The one-to-one contract must hold regardless of question complexity.
-    The model is expected to pick the most specific and actionable sub-topic.
+    The multi-subtopic path must work end-to-end: one LLM call, two candidates
+    with the same source question and retrieved_context.
     """
-    response = _ExtractedTheme(
-        sub_topic="housing voucher impact on school access",
-        description=(
-            "Shortage of housing vouchers constrains where families can live, "
-            "limiting their children's school options."
+    response = _ExtractedTheme(themes=[
+        _SingleTheme(
+            sub_topic="Section 8 voucher availability",
+            description="Shortage of housing vouchers constrains where families can live.",
         ),
-    )
+        _SingleTheme(
+            sub_topic="school access limited by housing instability",
+            description="Families' school choices are restricted by where they can afford to live.",
+        ),
+    ])
     ctx = make_context(
         "doc1",
         AMBIGUOUS_QUESTION,
         similar_themes=[HOUSING_THEME, EDUCATION_THEME],
     )
+    llm = FakeLLM(response)
+    candidates = run_extract_candidates([ctx], llm)
+    assert len(candidates) == 2
+    assert llm.calls  # LLM was called exactly once
+    assert len(llm.calls) == 1
+
+
+def test_hard_case_multi_candidate_shares_source_question():
+    """Both candidates from a multi-topic question carry the verbatim question."""
+    response = _ExtractedTheme(themes=[
+        _SingleTheme(sub_topic="housing", description="desc1"),
+        _SingleTheme(sub_topic="education", description="desc2"),
+    ])
+    ctx = make_context("doc1", AMBIGUOUS_QUESTION)
     candidates = run_extract_candidates([ctx], FakeLLM(response))
-    assert len(candidates) == 1
+    for c in candidates:
+        assert c.source_question == AMBIGUOUS_QUESTION
+
+
+def test_hard_case_multi_candidate_shares_doc_id():
+    """Both candidates from a multi-topic question carry the same doc_id."""
+    response = _ExtractedTheme(themes=[
+        _SingleTheme(sub_topic="housing", description="desc1"),
+        _SingleTheme(sub_topic="education", description="desc2"),
+    ])
+    ctx = make_context("doc-xyz", AMBIGUOUS_QUESTION)
+    candidates = run_extract_candidates([ctx], FakeLLM(response))
+    for c in candidates:
+        assert c.doc_id == "doc-xyz"
 
 
 def test_hard_case_source_question_preserved_verbatim():


### PR DESCRIPTION
## Summary

- Changed `_ExtractedTheme` schema from a single `(sub_topic, description)` pair to `themes: list[_SingleTheme]` — one LLM call per question, 1-N sub-topics returned
- `run_extract_candidates` flattens: each `_SingleTheme` produces one `ThemeCandidate` sharing `source_question`, `doc_id`, `retrieved_context`
- Prompts explicitly discourage over-splitting ("Most questions have exactly one sub-topic")
- No downstream changes needed — classify/write-back consume `list[ThemeCandidate]` without cardinality assumptions

## Test plan

- [x] `uv run pytest tests/test_extract_candidates.py -v` — 31 tests all pass
- [x] `uv run pytest` — 294 passed, 5 skipped
- [x] Hard-case test `test_hard_case_ambiguous_question_can_produce_multiple_candidates` verifies two-theme response → two candidates, one LLM call

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)