### PR TITLE
fix: case-insensitive decision matching in feedback.apply_decisions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,24 @@ Append-only log of work completed, decisions made, and things deferred. One entr
 
 ---
 
+## Issue #46 — Case-insensitive decision matching in feedback.apply_decisions
+
+**Date:** 2026-03-26
+
+**Branch:** `issue-46-case-insensitive-decisions`
+
+**What was built:**
+
+One-line fix in `apply_decisions`: `.strip().title()` normalises the incoming decision value before comparison, so `"RENAME"`, `"rename"`, and `"Rename"` all route correctly. Previously `"RENAME"` fell through to the unknown-decision warning and was silently skipped.
+
+5 new tests covering `ACCEPT`/`RENAME`/`REJECT` in uppercase and `accept`/`rename` in lowercase. 299 total pass.
+
+**Key decisions:**
+
+- `.title()` is the right normaliser here: decision values are single title-case words, so `.title()` converts any casing to the canonical form without affecting anything else. `.lower()` would require changing the constants or comparisons; `.title()` requires no other changes.
+
+---
+
 ## Issue #44 — Support multiple sub-topics (and output rows) per question
 
 **Date:** 2026-03-26

--- a/src/documenters_cle_langchain/feedback.py
+++ b/src/documenters_cle_langchain/feedback.py
@@ -180,7 +180,7 @@ def apply_decisions(
     library: dict[str, ThemeRecord] = {r.sub_topic: r for r in base_library}
 
     for dec in decisions:
-        decision = dec["decision"].strip()
+        decision = dec["decision"].strip().title()
 
         if not decision or decision == DECISION_REJECT:
             continue

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -253,6 +253,52 @@ def test_unknown_decision_is_skipped():
 
 
 # ---------------------------------------------------------------------------
+# apply_decisions — Case-insensitive decision matching (Issue #46)
+# ---------------------------------------------------------------------------
+
+def test_uppercase_accept_is_treated_as_accept():
+    decisions = [make_decision(decision="ACCEPT", sub_topic="some theme", topic="HOUSING")]
+    result = apply_decisions([], decisions)
+    assert len(result) == 1
+
+
+def test_uppercase_rename_is_treated_as_rename():
+    decisions = [make_decision(
+        decision="RENAME",
+        sub_topic="bad label",
+        corrected_sub_topic="good label",
+        topic="HOUSING",
+    )]
+    result = apply_decisions([], decisions)
+    assert len(result) == 1
+    assert result[0].sub_topic == "good label"
+
+
+def test_uppercase_reject_is_treated_as_reject():
+    decisions = [make_decision(decision="REJECT", sub_topic="should not appear")]
+    result = apply_decisions([], decisions)
+    assert result == []
+
+
+def test_lowercase_accept_is_treated_as_accept():
+    decisions = [make_decision(decision="accept", sub_topic="some theme", topic="HOUSING")]
+    result = apply_decisions([], decisions)
+    assert len(result) == 1
+
+
+def test_lowercase_rename_is_treated_as_rename():
+    decisions = [make_decision(
+        decision="rename",
+        sub_topic="bad label",
+        corrected_sub_topic="good label",
+        topic="HOUSING",
+    )]
+    result = apply_decisions([], decisions)
+    assert len(result) == 1
+    assert result[0].sub_topic == "good label"
+
+
+# ---------------------------------------------------------------------------
 # apply_decisions — Base library preservation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `apply_decisions` now normalizes the Decision column value with `.strip().title()` before comparison — `RENAME`, `rename`, and `Rename` all route correctly
- Previously any non-title-case input fell through to the unknown-decision warning and was silently skipped

## Test plan

- [ ] `uv run pytest tests/test_feedback.py -v` — 37 tests pass
- [ ] `uv run pytest` — 299 passed, 5 skipped

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)