### PR TITLE
fix: sub-topic extraction prompt generates recurring labels, not question summaries

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -27,6 +27,7 @@ Prompt changes only in `extract_candidates.py`. No logic changes.
 
 - Cross-cutting vs. domain-specific: the updated issue clarified that abstract concerns ("transparency", "accountability") should share a single cross-domain label. The earlier draft I wrote had this backwards (instructing the model to add domain qualifiers). Corrected before commit.
 - RAG exception for specific instances: the owner's comment asked that we preserve named labels for specific bills/funds/initiatives when they were previously named by a human reviewer. The guidance threads this: default to the abstract underlying issue, but defer to a retrieved label when one exists.
+- Compound labels (e.g. "prisons, motherhood and pregnancy"): added explicit guidance prohibiting comma-separated compound labels. The model already supports returning multiple `_SingleTheme` entries per question (from Issue #44); it just needed to be told to use that path rather than packing multiple issues into one label. Added a hard-case test using the prisons/maternal example showing the correct output is two separate candidates with no commas in either label.
 
 ---
 

--- a/src/documenters_cle_langchain/extract_candidates.py
+++ b/src/documenters_cle_langchain/extract_candidates.py
@@ -88,6 +88,13 @@ should both be labeled "transparency", not "housing transparency" and \
 underlying issue, use that label. Only create a new label when the question \
 is genuinely distinct from all retrieved themes.
 
+**One issue per label — no compound labels.** A sub-topic label names a \
+single civic concern. Never combine multiple issues into one label using \
+commas or slashes. Bad: "prisons, motherhood and pregnancy" — that is two \
+separate sub-topics: "prenatal care in county jails" and "maternal \
+reentry support". If a question covers two distinct issues, return two \
+separate sub-topic entries.
+
 Your job: given a follow-up question from a community reporter, propose one or \
 more sub-topic labels and 1-2 sentence descriptions of the underlying civic \
 concerns. Most questions map to exactly one sub-topic — only propose multiple \

--- a/tests/test_extract_candidates.py
+++ b/tests/test_extract_candidates.py
@@ -181,6 +181,42 @@ def test_prompt_user_emphasizes_recurrence():
     assert "recur" in content.lower()
 
 
+def test_prompt_system_no_compound_labels():
+    """System prompt must prohibit comma-separated compound labels and show correct split."""
+    content = build_extraction_prompt("What about prisons?", [])[0]["content"]
+    # The compound-label example and the instruction to return separate entries
+    assert "compound" in content.lower() or "one issue per label" in content.lower() or "separate sub-topic" in content.lower()
+
+
+def test_hard_case_compound_label_splits_into_two_entries():
+    """A question spanning two unrelated issues (prisons + maternal care) should produce
+    two separate ThemeCandidates, not one candidate with a comma-separated label."""
+    response = _ExtractedTheme(themes=[
+        _SingleTheme(
+            sub_topic="prenatal care in county jails",
+            description="Access to healthcare for pregnant people who are incarcerated.",
+        ),
+        _SingleTheme(
+            sub_topic="maternal reentry support",
+            description="Support services for mothers returning from incarceration.",
+        ),
+    ])
+    ctx = make_context(
+        "doc1",
+        "What resources exist for pregnant women who are incarcerated, "
+        "and what happens to them and their children after release?",
+    )
+    llm = FakeLLM(response)
+    candidates = run_extract_candidates([ctx], llm)
+    assert len(candidates) == 2
+    labels = {c.sub_topic for c in candidates}
+    assert "prenatal care in county jails" in labels
+    assert "maternal reentry support" in labels
+    # No compound label with a comma
+    for c in candidates:
+        assert "," not in c.sub_topic
+
+
 # ---------------------------------------------------------------------------
 # build_extraction_prompt — question and context content
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces "specific, concrete" framing with "recurring civic issue — abstract enough to recur across multiple Cleveland meetings over a year"
- Adds four counter-examples showing over-specific → right-level label pairs (from the issue)
- Cross-cutting themes (transparency, accountability) should NOT carry domain qualifiers — corrected from an earlier draft that had this backwards
- Adds RAG grounding: prefer retrieved labels; defer to specific named instances only when a human previously established them
- 6 new prompt-content tests; 304 total pass

## Test plan

- [ ] All 304 tests pass (`uv run pytest`)
- [ ] Spot-check: system prompt counter-examples present (`"municipal staffing and hiring"`, `"vacant land redevelopment"`)
- [ ] Spot-check: system prompt says NOT to add domain qualifiers to cross-cutting themes
- [ ] Spot-check: user prompt contains "recur" and no "most specific and actionable"

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)