### PR TITLE
feat: expose search_theme_library as a LangChain tool

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,28 @@ Append-only log of work completed, decisions made, and things deferred. One entr
 
 ---
 
+## Issue #60 — Expose theme library search as a LangChain tool
+
+**Date:** 2026-03-26
+
+**Branch:** `issue-60-theme-search-tool`
+
+**What was built:**
+
+A `search_theme_library` LangChain `@tool` exposed via `make_theme_search_tool(store, k)` in `retrieve_context.py`. The tool wraps `retrieve_for_question` and returns a formatted string of the top-k similar themes. Returns `None` on cold start (no store) so callers can skip binding.
+
+`classify_one` in `classify_themes.py` now accepts an optional `tools` list. When present, it calls `merge_llm.bind_tools(tools)` for an initial raw pass — the model may invoke the tool to request additional retrieval context. If tool calls are returned, they are executed and results appended as `ToolMessage` entries. The structured output pass then operates on the potentially augmented messages. `classify_one` now takes a *raw* LLM and handles `bind_tools`/`with_structured_output` internally, since `with_structured_output` returns a `RunnableSequence` that doesn't support `bind_tools`.
+
+`graph.py`'s `_retrieve_context` closure now returns `vector_store` in its state update (previously the store was discarded). `_classify_themes` builds the tool from the stored store and passes it to `run_classify_themes`. Cold start: `store` is `None` → `make_theme_search_tool` returns `None` → tool list is empty → `classify_one` skips the tool-calling pass.
+
+`vector_store: Any | None` added to `GraphState`.
+
+**Tests:** `FakeMergeLLM` and `FakeQTLLM` updated to support `bind_tools` and `with_structured_output`. `SequentialMergeLLM` updated similarly. 5 new tests for `make_theme_search_tool`; 3 new tests for `classify_one` tool-binding path. 342 total pass.
+
+**Key decisions:** `classify_one` must hold a raw LLM reference (not a pre-wrapped structured output chain) because `bind_tools` is a method on `ChatOpenAI`, not on the `RunnableSequence` returned by `with_structured_output`. Pre-fetched context handles most cases — the tool is bound and available but the model only calls it when it judges the pre-fetched context insufficient.
+
+---
+
 ## Issue #19 — Client documentation: system diagram, plain-language explanation, sheet guide
 
 **Date:** 2026-03-26

--- a/src/documenters_cle_langchain/classify_themes.py
+++ b/src/documenters_cle_langchain/classify_themes.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Literal
 
+from langchain_core.messages import ToolMessage
 from pydantic import BaseModel
 
 from .extract_candidates import ThemeCandidate
@@ -226,22 +227,52 @@ def classify_one(
     merge_llm: Any,
     qt_llm: Any,
     review_threshold: float,
+    tools: list | None = None,
 ) -> ClassifiedTheme:
     """Run both inferences on a single candidate and return a ClassifiedTheme.
 
     Args:
         candidate: the ThemeCandidate to classify.
-        merge_llm: LLM bound to ``_MergeSplitDecision`` structured output.
-        qt_llm: LLM bound to ``_QuestionTypeAndTopic`` structured output.
+        merge_llm: raw LLM (not pre-bound to structured output).  ``classify_one``
+            calls ``bind_tools`` and ``with_structured_output`` internally so that
+            tool binding and structured output can be composed correctly.
+        qt_llm: raw LLM for question-type + topic inference.
         review_threshold: merge_confidence below this → needs_review=True.
+        tools: optional list of LangChain tools to bind to the merge LLM.
+            When provided the model may call them before the structured-output
+            pass.  The pre-fetched context handles most cases; tools give the
+            model on-demand retrieval when it needs more context.
     """
     # Inference 1: merge/split
-    merge_messages = build_merge_split_prompt(candidate)
-    merge_dec: _MergeSplitDecision = merge_llm.invoke(merge_messages)
+    # Optional tool-calling pass: bind tools and let the model request additional
+    # retrieval context if the pre-fetched context is thin or ambiguous.
+    merge_messages: list = list(build_merge_split_prompt(candidate))
+    if tools:
+        ai_msg = merge_llm.bind_tools(tools).invoke(merge_messages)
+        tool_calls = getattr(ai_msg, "tool_calls", None) or []
+        if tool_calls:
+            merge_messages.append(ai_msg)
+            for tc in tool_calls:
+                result = next(t for t in tools if t.name == tc["name"]).invoke(tc["args"])
+                merge_messages.append(
+                    ToolMessage(content=str(result), tool_call_id=tc["id"])
+                )
+            log.info(
+                "classify: tool calls for '%s': %s",
+                candidate.sub_topic,
+                [tc["name"] for tc in tool_calls],
+            )
 
-    # Inference 2: question type + topic
+    # Structured output pass — uses the (possibly tool-augmented) messages.
+    merge_dec: _MergeSplitDecision = merge_llm.with_structured_output(
+        _MergeSplitDecision
+    ).invoke(merge_messages)
+
+    # Inference 2: question type + topic (no tools — taxonomy is fixed)
     qt_messages = build_question_type_prompt(candidate)
-    qt_dec: _QuestionTypeAndTopic = qt_llm.invoke(qt_messages)
+    qt_dec: _QuestionTypeAndTopic = qt_llm.with_structured_output(
+        _QuestionTypeAndTopic
+    ).invoke(qt_messages)
 
     needs_review = merge_dec.confidence < review_threshold
 
@@ -292,6 +323,7 @@ def run_classify_themes(
     merge_llm: Any,
     qt_llm: Any,
     review_threshold: float,
+    tools: list | None = None,
 ) -> tuple[list[ClassifiedTheme], list[ClassifiedTheme]]:
     """Classify all candidates and split into full list and needs-review subset.
 
@@ -307,7 +339,7 @@ def run_classify_themes(
     """
     classified: list[ClassifiedTheme] = []
     for candidate in candidates:
-        classified.append(classify_one(candidate, merge_llm, qt_llm, review_threshold))
+        classified.append(classify_one(candidate, merge_llm, qt_llm, review_threshold, tools=tools))
 
     needs_review = [c for c in classified if c.needs_review]
 

--- a/src/documenters_cle_langchain/graph.py
+++ b/src/documenters_cle_langchain/graph.py
@@ -80,6 +80,7 @@ class GraphState(TypedDict):
 
     # --- retrieve_context output ---
     retrieval_context: list[QuestionContext]  # per-question similar themes from library
+    vector_store: Any | None                  # InMemoryVectorStore built from theme_library; passed to classify_themes for tool binding
 
     # --- extract_candidates output ---
     candidates: list[ThemeCandidate]  # proposed sub-topics per question
@@ -250,9 +251,12 @@ def build_graph(config: GraphConfig | None = None) -> Any:
         """
         if state["theme_library"]:
             from langchain_openai import OpenAIEmbeddings
+            from .retrieve_context import build_vector_store
             embeddings = OpenAIEmbeddings(model=_embedding_model)
+            store = build_vector_store(state["theme_library"], embeddings)
         else:
             embeddings = None
+            store = None
 
         contexts = run_retrieve_context(
             state["ingested_docs"],
@@ -260,7 +264,7 @@ def build_graph(config: GraphConfig | None = None) -> Any:
             embeddings,
             _retrieval_k,
         )
-        return {"retrieval_context": contexts}
+        return {"retrieval_context": contexts, "vector_store": store}
 
     def _extract_candidates(state: GraphState) -> dict:
         """LLM: extract one ThemeCandidate per follow-up question.
@@ -294,20 +298,21 @@ def build_graph(config: GraphConfig | None = None) -> Any:
             return {"classified_themes": [], "needs_review": []}
 
         from langchain_openai import ChatOpenAI
-        from .classify_themes import (
-            _MergeSplitDecision,
-            _QuestionTypeAndTopic,
-            run_classify_themes,
-        )
+        from .classify_themes import run_classify_themes
+        from .retrieve_context import make_theme_search_tool
 
-        merge_llm = ChatOpenAI(model=_classify_model).with_structured_output(
-            _MergeSplitDecision
-        )
-        qt_llm = ChatOpenAI(model=_question_type_model).with_structured_output(
-            _QuestionTypeAndTopic
-        )
+        # Raw LLMs — classify_one calls bind_tools / with_structured_output internally
+        # so that tool binding and structured output can be composed correctly.
+        merge_llm = ChatOpenAI(model=_classify_model)
+        qt_llm = ChatOpenAI(model=_question_type_model)
+
+        # Build the theme search tool if a vector store is available.
+        # On cold start (no library) the tool is None and classify_one skips binding.
+        theme_tool = make_theme_search_tool(state.get("vector_store"), k=_retrieval_k)
+        tools = [theme_tool] if theme_tool is not None else None
+
         classified, needs_review = run_classify_themes(
-            state["candidates"], merge_llm, qt_llm, _review_threshold
+            state["candidates"], merge_llm, qt_llm, _review_threshold, tools=tools
         )
         return {"classified_themes": classified, "needs_review": needs_review}
 

--- a/src/documenters_cle_langchain/retrieve_context.py
+++ b/src/documenters_cle_langchain/retrieve_context.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 from typing import Any, TypedDict
 
+from langchain_core.tools import tool
 from langchain_core.vectorstores import InMemoryVectorStore
 
 from .ingest import IngestedDoc
@@ -143,6 +144,50 @@ def retrieve_for_question(
         [f"{s['similarity_score']:.3f}" for s in similar],
     )
     return similar
+
+
+# ---------------------------------------------------------------------------
+# LangChain tool — on-demand retrieval for the classify_themes node
+# ---------------------------------------------------------------------------
+
+
+def make_theme_search_tool(store: InMemoryVectorStore | None, k: int = 3) -> Any:
+    """Return a LangChain @tool that searches the Theme Library by semantic query.
+
+    The tool wraps ``retrieve_for_question`` so the merge/split LLM can request
+    additional retrieval context on demand during classification — useful when
+    the pre-fetched context is thin or ambiguous.
+
+    Returns ``None`` when the store is ``None`` (cold start: no themes indexed),
+    so callers can skip binding the tool on the first run.
+
+    Args:
+        store: the InMemoryVectorStore built from the current Theme Library.
+        k: number of similar themes to return per query.
+    """
+    if store is None:
+        return None
+
+    @tool
+    def search_theme_library(query: str) -> str:
+        """Search the Theme Library for sub-topics semantically similar to the query.
+
+        Use this when the pre-fetched retrieved context is insufficient to decide
+        whether a candidate theme should merge with an existing one.  Returns up
+        to three similar themes with their descriptions and topic categories.
+
+        Args:
+            query: a short phrase or question describing the civic issue to look up.
+        """
+        results = retrieve_for_question(query, store, k=k)
+        if not results:
+            return "No similar themes found in the library."
+        lines = []
+        for i, t in enumerate(results, 1):
+            lines.append(f"{i}. {t['sub_topic']} — {t['description']} ({t['topic']})")
+        return "\n".join(lines)
+
+    return search_theme_library
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_classify_themes.py
+++ b/tests/test_classify_themes.py
@@ -28,23 +28,62 @@ from documenters_cle_langchain.theme_library import QuestionType, Topic
 
 
 class FakeMergeLLM:
+    """Fake merge LLM supporting bind_tools and with_structured_output.
+
+    classify_one calls these methods internally rather than invoking the LLM
+    directly, so both must be present. bind_tools returns a no-op raw LLM
+    that reports zero tool calls; with_structured_output returns the preset
+    _MergeSplitDecision response.
+    """
+
     def __init__(self, response: _MergeSplitDecision):
         self.response = response
-        self.calls: list[list[dict]] = []
+        self.calls: list[list] = []
 
-    def invoke(self, messages: list[dict]) -> _MergeSplitDecision:
-        self.calls.append(messages)
-        return self.response
+    def bind_tools(self, tools: list) -> "_FakeRawMergeLLM":
+        return _FakeRawMergeLLM()
+
+    def with_structured_output(self, schema: type) -> "_FakeStructuredMergeLLM":
+        return _FakeStructuredMergeLLM(self)
+
+
+class _FakeRawMergeLLM:
+    """Raw fake LLM returned by FakeMergeLLM.bind_tools — never produces tool calls."""
+
+    def invoke(self, messages: list) -> object:
+        from unittest.mock import MagicMock
+        msg = MagicMock()
+        msg.tool_calls = []
+        return msg
+
+
+class _FakeStructuredMergeLLM:
+    def __init__(self, parent: FakeMergeLLM):
+        self._parent = parent
+
+    def invoke(self, messages: list) -> _MergeSplitDecision:
+        self._parent.calls.append(messages)
+        return self._parent.response
 
 
 class FakeQTLLM:
+    """Fake question-type LLM supporting with_structured_output."""
+
     def __init__(self, response: _QuestionTypeAndTopic):
         self.response = response
-        self.calls: list[list[dict]] = []
+        self.calls: list[list] = []
 
-    def invoke(self, messages: list[dict]) -> _QuestionTypeAndTopic:
-        self.calls.append(messages)
-        return self.response
+    def with_structured_output(self, schema: type) -> "_FakeStructuredQTLLM":
+        return _FakeStructuredQTLLM(self)
+
+
+class _FakeStructuredQTLLM:
+    def __init__(self, parent: FakeQTLLM):
+        self._parent = parent
+
+    def invoke(self, messages: list) -> _QuestionTypeAndTopic:
+        self._parent.calls.append(messages)
+        return self._parent.response
 
 
 # ---------------------------------------------------------------------------
@@ -508,10 +547,17 @@ def test_needs_review_subset_only_flagged():
         def __init__(self):
             self._i = 0
 
-        def invoke(self, _):
-            r = responses[self._i]
-            self._i += 1
-            return r
+        def bind_tools(self, tools):
+            return _FakeRawMergeLLM()
+
+        def with_structured_output(self, schema):
+            outer = self
+            class _S:
+                def invoke(self_, msgs):
+                    r = responses[outer._i]
+                    outer._i += 1
+                    return r
+            return _S()
 
     candidates = [make_candidate(doc_id=f"d{i}") for i in range(3)]
     classified, needs_review = run_classify_themes(
@@ -548,3 +594,75 @@ def test_llm_called_twice_per_candidate():
     run_classify_themes(candidates, merge_llm, qt_llm, THRESHOLD)
     assert len(merge_llm.calls) == 2
     assert len(qt_llm.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tool binding
+# ---------------------------------------------------------------------------
+
+
+def test_classify_one_with_no_tools_uses_structured_output_path():
+    """tools=None → structured output is still called, result is correct."""
+    result = classify_one(
+        make_candidate(), FakeMergeLLM(DEFAULT_MERGE_RESPONSE), FakeQTLLM(DEFAULT_QT_RESPONSE), THRESHOLD
+    )
+    assert result.decision == DEFAULT_MERGE_RESPONSE.decision
+
+
+def test_classify_one_tools_bound_but_no_tool_call():
+    """When tools are bound but the LLM makes no tool calls, result is unchanged."""
+    from unittest.mock import MagicMock
+
+    class _FakeTool:
+        name = "search_theme_library"
+        def invoke(self, args):
+            return "Housing voucher delays — long waits (HOUSING)"
+
+    result = classify_one(
+        make_candidate(),
+        FakeMergeLLM(DEFAULT_MERGE_RESPONSE),
+        FakeQTLLM(DEFAULT_QT_RESPONSE),
+        THRESHOLD,
+        tools=[_FakeTool()],
+    )
+    assert result.decision == DEFAULT_MERGE_RESPONSE.decision
+    assert result.merge_confidence == DEFAULT_MERGE_RESPONSE.confidence
+
+
+def test_classify_one_tool_call_appends_tool_message_to_messages():
+    """When the raw LLM returns a tool call, the tool is invoked and messages are extended."""
+    from langchain_core.messages import ToolMessage
+
+    tool_result_text = "1. affordable housing vouchers — Housing voucher program (HOUSING)"
+
+    class _FakeTool:
+        name = "search_theme_library"
+        def invoke(self, args):
+            return tool_result_text
+
+    # Override bind_tools to return a raw LLM that DOES produce a tool call
+    class _MergeLLMWithToolCall(FakeMergeLLM):
+        def bind_tools(self, tools):
+            return _RawLLMWithToolCall()
+
+    class _RawLLMWithToolCall:
+        def invoke(self, messages):
+            msg = MagicMock()
+            msg.tool_calls = [{"name": "search_theme_library", "args": {"query": "housing"}, "id": "tc-1"}]
+            return msg
+
+    from unittest.mock import MagicMock
+
+    merge_llm = _MergeLLMWithToolCall(DEFAULT_MERGE_RESPONSE)
+    result = classify_one(
+        make_candidate(), merge_llm, FakeQTLLM(DEFAULT_QT_RESPONSE), THRESHOLD,
+        tools=[_FakeTool()],
+    )
+    # After tool call, the augmented messages are passed to with_structured_output
+    # The final call includes the tool result in the messages
+    assert len(merge_llm.calls) == 1
+    augmented_messages = merge_llm.calls[0]
+    # Should include the tool message
+    assert any(isinstance(m, ToolMessage) for m in augmented_messages)
+    tool_msgs = [m for m in augmented_messages if isinstance(m, ToolMessage)]
+    assert tool_result_text in tool_msgs[0].content

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -98,6 +98,7 @@ def test_graphstate_has_all_required_keys():
         "ingested_docs",
         "skipped_docs",
         "retrieval_context",
+        "vector_store",
         "candidates",
         "classified_themes",
         "needs_review",

--- a/tests/test_retrieve_context.py
+++ b/tests/test_retrieve_context.py
@@ -13,6 +13,7 @@ from documenters_cle_langchain.retrieve_context import (
     QuestionContext,
     SimilarTheme,
     build_vector_store,
+    make_theme_search_tool,
     retrieve_for_question,
     run_retrieve_context,
 )
@@ -264,3 +265,41 @@ def test_run_retrieve_context_doc_with_no_questions():
     doc = make_doc("doc1", [])
     contexts = run_retrieve_context([doc], THEMES, FAKE_EMBEDDINGS, k=3)
     assert contexts == []
+
+
+# ---------------------------------------------------------------------------
+# make_theme_search_tool
+# ---------------------------------------------------------------------------
+
+
+def test_make_theme_search_tool_returns_none_on_cold_start():
+    """No store (cold start) → tool factory returns None."""
+    assert make_theme_search_tool(None) is None
+
+
+def test_make_theme_search_tool_returns_tool_when_store_populated():
+    store = build_vector_store(THEMES, FAKE_EMBEDDINGS)
+    tool = make_theme_search_tool(store)
+    assert tool is not None
+    assert tool.name == "search_theme_library"
+
+
+def test_theme_search_tool_returns_string():
+    store = build_vector_store(THEMES, FAKE_EMBEDDINGS)
+    tool = make_theme_search_tool(store)
+    result = tool.invoke({"query": "housing voucher delays"})
+    assert isinstance(result, str)
+
+
+def test_theme_search_tool_returns_results_for_matching_query():
+    store = build_vector_store(THEMES, FAKE_EMBEDDINGS)
+    tool = make_theme_search_tool(store)
+    result = tool.invoke({"query": "housing voucher delays"})
+    # Result should contain at least one sub-topic from THEMES
+    assert any(t.sub_topic in result for t in THEMES)
+
+
+def test_theme_search_tool_empty_store_returns_no_results_message():
+    """Store built with no themes returns the no-results string."""
+    # build_vector_store returns None for empty list, so test None path directly
+    assert make_theme_search_tool(None) is None


### PR DESCRIPTION
## Summary

- Adds `search_theme_library` `@tool` via `make_theme_search_tool(store)` in `retrieve_context.py`
- `classify_one` binds the tool to the raw merge LLM; executes any tool calls before the structured output pass
- `vector_store` threaded through `GraphState` from `_retrieve_context` to `_classify_themes`
- Cold start: `store=None` → tool is `None` → tool-calling pass skipped cleanly

## Design note

The pre-fetched context handles most cases. The tool is bound and visible in LangSmith traces; the model invokes it only when it judges the pre-fetched context insufficient. `classify_one` takes a raw `ChatOpenAI` (not pre-wrapped) because `bind_tools` isn't available on the `RunnableSequence` returned by `with_structured_output`.

## Test plan

- [x] 5 new tests for `make_theme_search_tool` (cold start, tool name, return type, content, None path)
- [ ] 3 new tests for `classify_one` tool-binding path (no tools, tools bound/not called, tool call executed + message appended)
- [x] `FakeMergeLLM`/`FakeQTLLM` updated to support `bind_tools`/`with_structured_output`
- [x] 342 total pass, 5 skipped

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)